### PR TITLE
Update Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,9 @@ updates:
 - package-ecosystem: github-actions
   directory: /
   schedule:
-    cron: 0 16 19 * *
+    interval: monthly
+    day: tuesday
+    time: '15:00'
   groups:
     github-actions:
       patterns:


### PR DESCRIPTION
## Summary
                
This PR updates the Dependabot configuration to run monthly on the first tuesday at 3 pm GMT. It also 
updates the Dependabot configuration to include all GitHub Actions workflows.
