### PR TITLE
Automated release notes

### DIFF
--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -1,0 +1,34 @@
+name: Post-Release Actions
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  update-docs-release-notes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout react-native
+        uses: actions/checkout@v4
+        with:
+          path: react-native
+      - name: Checkout docs
+        uses: actions/checkout@v4
+        with:
+          repository: smileidentity/docs
+          path: docs
+          token: ${{ secrets.GH_PAT }}
+      - name: Copy CHANGELOG.md to Release Notes
+        run: cp react-native/CHANGELOG.md docs/integration-options/mobile/react-native-v10/release-notes.md
+      - name: Create docs PR
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GH_PAT }}
+          path: docs
+          commit-message: React Native ${{ github.event.release.tag_name }} Release Notes
+          title: React Native ${{ github.event.release.tag_name }} Release Notes
+          body: Automated PR to update the release notes
+          branch: react-native-release-notes-${{ github.event.release.tag_name }}
+          labels: "release-notes"
+          team-reviewers: "smileidentity/mobile"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,69 +1,51 @@
+# Release Notes
+
 ## 10.0.1
 
-### Added
-- Networking for iOS
+* Networking for iOS
 
-### Changed
-
-### Fixed
-
-### Removed
 ## 10.0.0
 
-### Added
-- Remove beta
-### Changed
+* Remove beta
+* iOS: Biometric KYC allow agent mode
+* iOS: Document capture captureBothSides fixes
+* iOS: Biometric KYC invalid payload fixes
+* Android: Document capture crash fixes
+* iOS & Android: Consent screen import fixes
 
-### Fixed
-- IOS:Biometric KYC allow agent mode
-- IOS:Document capture captureBothSides fixes
-- IOS:Biometric KYC invalid payload fixes
-- Android: Document capture crash fixes
-- IOS & Android: Consent screen import fixes
-### Removed
 ## 10.0.0-beta03
 
-### Added
-- Added networking wrappers
-- Allow new enroll flag
-
-### Changed
-
-### Fixed
-- Android docv and enhanced docv crashes
-- IOS docv and enhanced docv crashes
+* Added networking wrappers
+* Allow new enroll flag
+* Android DocV and Enhanced DocV crashes
+* iOS DocV and enhanced DocV crashes
 
 ## 10.0.0-beta02
 
 ### Added
-- Added support for both android and iOS
-- Support for Biometric KYC
-- Support for Consent Screen
-- Support for Document Verification
-- Support for Enhanced Document Verification
-- Support for SmartSelfie Enrollment
-- Support for SmartSelfie Authentication
-- Support for Enhanced KYC
-- Support for Async Enhanced KYC
+
+* iOS
+  * SmartSelfie™  Enrolment
+  * SmartSelfie™ Authentication
+  * Document Verification
+  * Enhanced Document Verification
+  * Biometric KYC
+  * Consent Screen
+* Android
+  * Enhanced Document Verification
+  * Consent Screen
 
 ### Changed
-- Removed product prop in favor of using props as per the rest of the SDKs
 
-### Removed
-- BVN Consent in favor of consent screen as that is available on both platforms
+* SmartSelfie™  Enrolment
+* SmartSelfie™ Authentication
+* Document Verification
 
 ## 10.0.0-beta01
 
-### Added
-- Initial release focused on the below products only for Android
-- Support for Biometric KYC
-- Support for BVN Consent
-- Support for Document Verification
-- Support for SmartSelfie Enrollment
-- Support for SmartSelfie Authentication
-
-### Changed
-
-### Fixed
-
-### Removed
+* Initial release
+* Support for Android only
+  * SmartSelfie™  Enrolment
+  * SmartSelfie™ Authentication
+  * Document Verification
+  * Biometric KYC


### PR DESCRIPTION
## Summary

Automates updating the Release Notes in our docs by copying over the changelog when a new release is created. GitBook uses a slightly different format, so I've replaced the current CHANGELOG.md with the current the GitBook contents. That will allow the diff to be only the new changes going forward. 

As always, the `## Unreleased` needs to be turned into an actual version number prior to performing a release. But even if forgotten, it can still be changed on the docs PR prior to merge.