### PR TITLE
fix: include callbackurl on main js interface

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -87,7 +87,7 @@ android {
   }
 
   composeOptions {
-    kotlinCompilerExtensionVersion '1.5.11'
+    kotlinCompilerExtensionVersion rootProject.ext.has("kotlinCompilerExtensionVersion") ? rootProject.ext.get("kotlinCompilerExtensionVersion") : '1.5.11'
   }
 
   compileOptions {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -245,6 +245,13 @@ const SmileID = {
     request.numAttempts = numAttempts;
     return _SmileID.pollEnhancedDocumentVerificationJobStatus(request);
   },
+
+  /**
+   * The callback mechanism allows for asynchronous job requests and responses.
+   * While the job_status API can be polled to get a result, a better method is to set up a
+   * callback url and let the system POST a JSON response.
+   */
+  setCallbackUrl: (callbackUrl: string) => _SmileID.setCallbackUrl(callbackUrl),
 };
 
 export {


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/xxx

## Summary

- The `setCallbackUrl` currently isn't proxied through the JS interface onto the respective native methods, this change just adds that. This allows the url to be set in the app as opposed to within the Smile Dashboard

- Additionally, a feature has been added to parameterize the kotlin compiler version so that projects using different composer/kotlin versions don't have compatibility issues

## Known Issues
n/a

## Test Instructions
- Execute `SmileID.setCallbackUrl` from the JS code in the app.
- Add `kotlinCompilerExtensionVersion` to `gradle.properties` to change the compiler extension version

## Screenshot
n/a