### PR TITLE
fix: tsconfig baseUrl

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig",
-  "exclude": ["example"]
+  "exclude": ["example"],
+  "compilerOptions": {
+    "rootDir": "./src"
+  }
 }


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/xxx

## Summary

This PR fixes the TS declaration files not been found introduced in [v10.1.4](https://github.com/smileidentity/react-native/releases/tag/v10.1.4) where `baseUrl` was changed  to `rootDir`. This causes the `lib/typescript` to also have another directory `src` which is not representative of the types declaration in `package.json` which points to `lib/typescript/index.d.ts` instead of `lib/typescript/src/index.d.ts`.

## Known Issues
N/A

## Test Instructions

Concise test instructions on how to verify that your feature works as intended. This should include
changes to the development environment (if applicable) and all commands needed to run your work.

## Screenshot
N/A
