### PR TITLE
fix: kotlin version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
   dependencies {
     classpath "com.android.tools.build:gradle:8.3.2"
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    if (kotlinVersion?.startsWith("2")) {
+    if (kotlin_version?.startsWith("2")) {
       classpath "org.jetbrains.kotlin:compose-compiler-gradle-plugin:$kotlin_version"
     }
     classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/xxx

## Summary
In the build.grade the kotlin version is defined in[ line 5](https://github.com/smileidentity/react-native/blob/7c0b287c1175936ad69727d3cd15b6fa81db6a76/android/build.gradle#L5) as `kotlin_version` and we read it in [line 16](https://github.com/smileidentity/react-native/blob/7c0b287c1175936ad69727d3cd15b6fa81db6a76/android/build.gradle#L16) as `kotlinVersion` which fails. This PR fixes it.


## Known Issues
-

## Test Instructions
Open the project (android) in Android studio and do a sync

## Screenshot
-
