### PR TITLE
Fix/allow new enroll as bool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Release Notes
 
-## Unreleased
+## 10.3.0
 * Changes the `allow_new_enroll` flag to be a real boolean instead of a string for prepUpload
   requests and multi-part requests. This is a breaking change for stored offline jobs, where the job
   is written using an older sdk version and then submission is attempted using this version.
+* Bump android to 10.6.0 (https://github.com/smileidentity/android/releases/tag/v10.6.0)
+* Bump iOS to 10.5.0 (https://github.com/smileidentity/ios/releases/tag/v10.5.0)
 
 ## 10.2.6
 * Added enhanced SmartSelfie™ capture Selfie capture screen component

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## Unreleased
+* Changes the `allow_new_enroll` flag to be a real boolean instead of a string for prepUpload
+  requests and multi-part requests. This is a breaking change for stored offline jobs, where the job
+  is written using an older sdk version and then submission is attempted using this version.
+
 ## 10.2.6
 * Added enhanced SmartSelfie™ capture Selfie capture screen component
 * Added `skipApiSubmission` to SmartSelfie™ capture which defaults to `false` and will allow Selfie capture without submission to the api

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,5 +3,5 @@ SmileId_minSdkVersion=21
 SmileId_targetSdkVersion=35
 SmileId_compileSdkVersion=35
 SmileId_ndkversion=21.4.7075529
-SmileId_androidVersion=10.5.2
+SmileId_androidVersion=10.6.0
 SmileId_kotlinCompilerExtensionVersion=1.5.11

--- a/android/src/main/java/com/smileidentity/react/Mapper.kt
+++ b/android/src/main/java/com/smileidentity/react/Mapper.kt
@@ -79,8 +79,7 @@ fun ReadableMap.toPrepUploadRequest(): PrepUploadRequest {
     timestamp = getStringOrDefault("timestamp") ?: run {
       throw IllegalArgumentException("timestamp is required")
     },
-    //TODO: Remove this and use strings once the backend is updated
-    allowNewEnroll = getBoolOrDefault("allowNewEnroll", false).toString(),
+    allowNewEnroll = getBoolOrDefault("allowNewEnroll", false),
     signature = getStringOrDefault("signature") ?: run {
       throw IllegalArgumentException("signature is required")
     },

--- a/ios/Utils/SmileIDDictExt.swift
+++ b/ios/Utils/SmileIDDictExt.swift
@@ -10,7 +10,7 @@ extension NSDictionary {
       testLambdaUrl: (self["testLambdaUrl"] as? String)!
     )
   }
-  
+
   func toAuthenticationRequest() -> AuthenticationRequest? {
     guard let jobTypeValue = self["jobType"] as? Int,
           let jobType = JobType(rawValue: jobTypeValue),
@@ -19,11 +19,11 @@ extension NSDictionary {
     else {
       return nil
     }
-    
+
     let country = self["country"] as? String
     let idType = self["idType"] as? String
     let updateEnrolledImage = self["updateEnrolledImage"] as? Bool
-    
+
     return AuthenticationRequest(
       jobType: jobType,
       updateEnrolledImage: updateEnrolledImage,
@@ -33,41 +33,43 @@ extension NSDictionary {
       idType: idType
     )
   }
-  
+
   func toPrepUploadRequest() -> PrepUploadRequest? {
     guard let partnerParamsDict = self["partnerParams"] as? NSDictionary,
           let partnerParams = partnerParamsDict.toPartnerParams(),
           let callbackUrl = self["callbackUrl"] as? String,
+          let allowNewEnroll = self["allowNewEnroll"] as? Bool,
           let partnerId = self["partnerId"] as? String,
           let timestamp = self["timestamp"] as? String,
           let signature = self["signature"] as? String
     else {
       return nil
     }
-    
+
     return PrepUploadRequest(
       partnerParams: partnerParams,
       callbackUrl: callbackUrl,
+      allowNewEnroll: allowNewEnroll,
       partnerId: partnerId,
       sourceSdk: self["sourceSdk"] as? String ?? "ios (react-native)",
       timestamp: timestamp,
       signature: signature
     )
   }
-  
+
   func toUploadRequest() -> UploadRequest? {
     guard let imagesArray = self["images"] as? [NSDictionary] else {
       return nil
     }
     let images = imagesArray.compactMap { $0.toUploadImageInfo() }
     let idInfo = (self["idInfo"] as? NSDictionary)?.toIdInfo()
-    
+
     return UploadRequest(
       images: images,
       idInfo: idInfo
     )
   }
-  
+
   func toUploadImageInfo() -> UploadImageInfo? {
     guard let imageTypeIdValue = self["imageTypeId"] as? String,
           let imageTypeId = ImageType(rawValue: imageTypeIdValue),
@@ -75,18 +77,18 @@ extension NSDictionary {
     else {
       return nil
     }
-    
+
     return UploadImageInfo(
       imageTypeId: imageTypeId,
       fileName: imageName
     )
   }
-  
+
   func toIdInfo() -> IdInfo? {
     guard let country = self["country"] as? String else {
       return nil
     }
-    
+
     let idType = self["idType"] as? String
     let idNumber = self["idNumber"] as? String
     let firstName = self["firstName"] as? String
@@ -95,7 +97,7 @@ extension NSDictionary {
     let dob = self["dob"] as? String
     let bankCode = self["bankCode"] as? String
     let entered = self["entered"] as? Bool
-    
+
     return IdInfo(
       country: country,
       idType: idType,
@@ -108,7 +110,7 @@ extension NSDictionary {
       entered: entered
     )
   }
-  
+
   func toConsentInfo() -> ConsentInformation {
     let consentGrantedDate = self["consentGrantedDate"] as? String ?? getCurrentIsoTimestamp()
     let personalDetailsConsentGranted = self["personalDetailsConsentGranted"] as? Bool ?? false
@@ -121,7 +123,7 @@ extension NSDictionary {
       documentInformationConsentGranted: documentInfoConsentGranted
     )
   }
-  
+
   func toEnhancedKycRequest() -> EnhancedKycRequest? {
     guard let country = self["country"] as? String,
           let idType = self["idType"] as? String,
@@ -140,7 +142,7 @@ extension NSDictionary {
     else {
       return nil
     }
-    
+
     let consentInfo: ConsentInformation
     if let consentInformation = self["consentInformation"] as? NSDictionary{
       consentInfo = consentInformation.toConsentInfo()
@@ -152,7 +154,7 @@ extension NSDictionary {
         documentInformationConsentGranted: false
       )
     }
-    
+
     return EnhancedKycRequest(
       country: country,
       idType: idType,
@@ -171,7 +173,7 @@ extension NSDictionary {
       signature: signature
     )
   }
-  
+
   func toJobStatusRequest() -> JobStatusRequest? {
     guard let userId = self["userId"] as? String,
           let jobId = self["jobId"] as? String,
@@ -183,7 +185,7 @@ extension NSDictionary {
     else {
       return nil
     }
-    
+
     return JobStatusRequest(
       userId: userId,
       jobId: jobId,
@@ -194,7 +196,7 @@ extension NSDictionary {
       signature: signature
     )
   }
-  
+
   func toProductsConfigRequest() -> ProductsConfigRequest? {
     guard let partnerId = self["partnerId"] as? String,
           let timestamp = self["timestamp"] as? String,
@@ -202,14 +204,14 @@ extension NSDictionary {
     else {
       return nil
     }
-    
+
     return ProductsConfigRequest(
       timestamp: timestamp,
       signature: signature,
       partnerId: partnerId
     )
   }
-  
+
   func toPartnerParams() -> PartnerParams? {
     guard let country = self["country"] as? String else {
       return nil
@@ -242,7 +244,7 @@ extension Dictionary where Key == String, Value == Any {
     }
     return jsonCompatibleDict
   }
-  
+
   private func convertToJSONCompatible(_ value: Any) -> Any {
     switch value {
     case let url as URL:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smile_identity/react-native",
-  "version": "10.2.6",
+  "version": "10.3.0",
   "description": "Official wrapper for the Smile ID <v10 android and iOS SDKs",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/react-native-smile-id.podspec
+++ b/react-native-smile-id.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://docs.usesmileid.com/.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
-  s.dependency "SmileID", "10.4.2"
+  s.dependency "SmileID", "10.5.0"
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/xxx

## Summary
This PR bumps the native versions and changes the `allow_new_enroll` flag to bool instead of string

## Known Issues
-

## Test Instructions
Run selfie and biometric kyc and check on the portal if the flags are set as bool

## Screenshot
-
