### PR TITLE
Fix Invalidator Bug 🐞

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * Added `applyLocalization()` function to enable partner-provided string translations on iOS via
 `SmileIDLocalizableStrings` to be applied in the SDK.
 
+### Fixed
+* Fixed the invalidator bug when `allowNewEnroll` is set to true
+
 ## 11.1.7 - January 23, 2026
 
 ### Changed

--- a/src/useSmileIDView.tsx
+++ b/src/useSmileIDView.tsx
@@ -26,7 +26,7 @@ export const useSmileIDView = (viewName: string, props: SmileIDProps) => {
         // Use the ref to access the latest callback
         setViewProps((prev) => ({
           ...prev,
-          userId: 'invalidator',
+          _invalidationKey: Date.now(),
         }));
         if (onResultRef.current) {
           const nativeEvent = {


### PR DESCRIPTION
### **User description**
Story: https://app.shortcut.com/smileid/story/xxx

## Summary

A few sentences/bullet points about the changes

## Known Issues

Any shortcomings in your work. This may include corner cases not correctly handled or issues related
to but not within the scope of your PR. Design compromises should be discussed here if they were not
already discussed above.

## Test Instructions

Concise test instructions on how to verify that your feature works as intended. This should include
changes to the development environment (if applicable) and all commands needed to run your work.

## Screenshot

If applicable (e.g. UI changes), add screenshots to help explain your work.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix invalidator using `_invalidationKey` instead of overwriting `userId`

- Prevents conflict when `allowNewEnroll` is true


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Event["onSmileResult event"]
  OldBehavior["Set userId to 'invalidator'"]
  NewBehavior["Set _invalidationKey to Date.now()"]
  ViewReset["View re-renders"]
  Event -- "before fix" --> OldBehavior
  Event -- "after fix" --> NewBehavior
  NewBehavior --> ViewReset
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useSmileIDView.tsx</strong><dd><code>Use _invalidationKey instead of overwriting userId</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/useSmileIDView.tsx

<ul><li>Replaced setting <code>userId</code> to <code>'invalidator'</code> with setting <code>_invalidationKey</code> <br>to <code>Date.now()</code> to trigger view re-render without corrupting the <code>userId</code> <br>prop</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/react-native-v11/pull/168/files#diff-7681401916660941bb29df036a3c2f52937e4dbdc9c49e34c063225745607bcb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Add changelog entry for invalidator bug fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added a "Fixed" entry documenting the invalidator bug fix when <br><code>allowNewEnroll</code> is set to true</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/react-native-v11/pull/168/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>