### PR TITLE
fix(ci): repair release_sdk workflow and trigger post-release reliably

### DIFF
--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -29,7 +29,7 @@ jobs:
             echo "RELEASE_TAG is empty; cannot proceed" >&2
             exit 1
           fi
-          if ! printf '%s' "${RELEASE_TAG}" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$'; then
+          if ! printf '%s' "${RELEASE_TAG}" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+(\.[0-9A-Za-z]+)*)?$'; then
             echo "RELEASE_TAG '${RELEASE_TAG}' is not a valid v-prefixed semver" >&2
             exit 1
           fi

--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -17,6 +17,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   update-docs-release-notes:
     runs-on: ubuntu-latest

--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -4,11 +4,35 @@ on:
   release:
     types:
       - created
+  workflow_call:
+    inputs:
+      tag_name:
+        description: 'Release tag to publish notes for (used when invoked from CI)'
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Release tag to publish notes for (e.g. v11.2.10)'
+        required: true
+        type: string
 
 jobs:
   update-docs-release-notes:
     runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ inputs.tag_name || github.event.release.tag_name }}
     steps:
+      - name: Validate release tag
+        run: |
+          if [ -z "${RELEASE_TAG}" ]; then
+            echo "RELEASE_TAG is empty; cannot proceed" >&2
+            exit 1
+          fi
+          if ! printf '%s' "${RELEASE_TAG}" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$'; then
+            echo "RELEASE_TAG '${RELEASE_TAG}' is not a valid v-prefixed semver" >&2
+            exit 1
+          fi
       - name: Checkout react-native
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -20,15 +44,15 @@ jobs:
           path: docs
           token: ${{ secrets.GH_PAT }}
       - name: Copy CHANGELOG.md to Release Notes
-        run: cp react-native/CHANGELOG.md docs/integration-options/mobile/react-native-v10/release-notes.md
+        run: cp react-native/CHANGELOG.md docs/integration-options/mobile/react-native-v11/release-notes.md
       - name: Create docs PR
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GH_PAT }}
           path: docs
-          commit-message: React Native ${{ github.event.release.tag_name }} Release Notes
-          title: React Native ${{ github.event.release.tag_name }} Release Notes
+          commit-message: React Native ${{ env.RELEASE_TAG }} Release Notes
+          title: React Native ${{ env.RELEASE_TAG }} Release Notes
           body: Automated PR to update the release notes
-          branch: react-native-release-notes-${{ github.event.release.tag_name }}
+          branch: react-native-release-notes-${{ env.RELEASE_TAG }}
           labels: "release-notes"
           team-reviewers: "smileidentity/mobile"

--- a/.github/workflows/release_sdk.yaml
+++ b/.github/workflows/release_sdk.yaml
@@ -56,7 +56,7 @@ jobs:
             echo "Tag ${new_tag} already exists locally" >&2
             exit 1
           fi
-          if git ls-remote --exit-code --tags origin "${new_tag}" >/dev/null 2>&1; then
+          if git ls-remote --exit-code --tags origin "refs/tags/${new_tag}" >/dev/null 2>&1; then
             echo "Tag ${new_tag} already exists on origin" >&2
             exit 1
           fi
@@ -71,9 +71,8 @@ jobs:
 
       - name: Publish package
         run: |
-          npm config set //registry.npmjs.org/:_authToken ${NODE_AUTH_TOKEN}
-          npm ci
-          npm run build
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
+          yarn prepare
           npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}

--- a/.github/workflows/release_sdk.yaml
+++ b/.github/workflows/release_sdk.yaml
@@ -2,75 +2,74 @@ name: 'Release SDK'
 
 on:
   workflow_dispatch:
-    inputs:
-      release_version:
-        type: choice
-        description: 'Select the version type to release'
-        required: true
-        default: patch
-        options:
-          - patch
-          - minor
-          - major
-          - beta
-          - alpha
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   release:
     uses: ./.github/workflows/ci.yml
 
-  bump-version:
+  publish:
+    name: Tag, release, and publish
     runs-on: ubuntu-latest
     needs: release
+    outputs:
+      new_tag: ${{ steps.read_version.outputs.new_tag }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_PAT }}
 
-      - name: Bump version
-        id: bump_version
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Configure git
         run: |
-          # Define function to parse and bump version number
-          bump_version() {
-            if [[ "$1" == "beta" || "$1" == "alpha" ]]; then
-              main_version="${current_version%-*}"
-              prerelease_version="${current_version#*-}"
-              prerelease_identifier="${prerelease_version%[0-9]*}"
-              numeric_part="${prerelease_version#$prerelease_identifier}"
-              numeric_part=$(printf "%01d" $((10#$numeric_part + 1)))
-              echo "${main_version}-${prerelease_identifier}${numeric_part}"
-            else
-              echo "$1"
-            fi
-          }
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
 
-          # Fetch current version and determine new version
-          current_version=$(node -p "require('./package.json').version")
-          new_version=$(bump_version "${{ github.event.inputs.release_version }}")
-
-          # Bump package version and output new version
-          npm version "$new_version" --no-git-tag-version
-          echo "new_version=$new_version" >> $GITHUB_ENV
-          echo "new_branch=release/$new_version" >> $GITHUB_ENV
-
-          echo "Version bumped to $new_version"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create Release Branch
+      - name: Read package version
+        id: read_version
         run: |
-          new_branch=$new_version
-          git checkout -b $new_branch
-          git push origin $new_branch
-
-      - name: Create Tag and Release
-        run: |
+          new_version=$(node -p "require('./package.json').version")
+          if [ -z "$new_version" ]; then
+            echo "Could not read version from package.json" >&2
+            exit 1
+          fi
+          if ! printf '%s' "$new_version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$'; then
+            echo "package.json version '$new_version' is not a valid semver" >&2
+            exit 1
+          fi
           new_tag="v$new_version"
-          git tag $new_tag
-          git push origin $new_tag
-          gh release create $new_tag --title "Release $new_tag" --notes "Release notes for $new_tag"
+          echo "new_version=$new_version" >> "$GITHUB_ENV"
+          echo "new_tag=$new_tag" >> "$GITHUB_ENV"
+          echo "new_tag=$new_tag" >> "$GITHUB_OUTPUT"
+          echo "Releasing $new_tag"
 
-      - name: Publish Package
+      - name: Verify tag does not already exist
+        run: |
+          if git rev-parse -q --verify "refs/tags/${new_tag}" >/dev/null; then
+            echo "Tag ${new_tag} already exists locally" >&2
+            exit 1
+          fi
+          if git ls-remote --exit-code --tags origin "${new_tag}" >/dev/null 2>&1; then
+            echo "Tag ${new_tag} already exists on origin" >&2
+            exit 1
+          fi
+
+      - name: Create tag and GitHub release
+        run: |
+          git tag "$new_tag"
+          git push origin "$new_tag"
+          gh release create "$new_tag" --title "Release $new_tag" --notes "Release notes for $new_tag"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+
+      - name: Publish package
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NODE_AUTH_TOKEN}
           npm ci
@@ -79,8 +78,10 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
 
-      - name: Create Pull Request
-        run: |
-          gh pr create --title "Merge release $new_version into main" --body "This is an automated pull request to update the version." --base main --head $new_branch
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  post-release:
+    name: Post-release actions
+    needs: publish
+    uses: ./.github/workflows/post_release.yml
+    with:
+      tag_name: ${{ needs.publish.outputs.new_tag }}
+    secrets: inherit

--- a/.github/workflows/release_sdk.yaml
+++ b/.github/workflows/release_sdk.yaml
@@ -18,6 +18,8 @@ jobs:
     name: Tag, release, and publish
     runs-on: ubuntu-latest
     needs: release
+    permissions:
+      contents: write
     outputs:
       new_tag: ${{ steps.read_version.outputs.new_tag }}
     steps:
@@ -25,7 +27,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_PAT }}
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -39,8 +40,9 @@ jobs:
         id: read_version
         run: |
           new_version=$(node -p "require('./package.json').version")
-          if [ -z "$new_version" ]; then
-            echo "Could not read version from package.json" >&2
+          pkg_name=$(node -p "require('./package.json').name")
+          if [ -z "$new_version" ] || [ -z "$pkg_name" ]; then
+            echo "Could not read name/version from package.json" >&2
             exit 1
           fi
           if ! printf '%s' "$new_version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$'; then
@@ -49,28 +51,59 @@ jobs:
           fi
           new_tag="v$new_version"
           echo "new_version=$new_version" >> "$GITHUB_ENV"
+          echo "pkg_name=$pkg_name" >> "$GITHUB_ENV"
           echo "new_tag=$new_tag" >> "$GITHUB_ENV"
           echo "new_tag=$new_tag" >> "$GITHUB_OUTPUT"
-          echo "Releasing $new_tag"
+          echo "Releasing $pkg_name $new_tag"
 
-      - name: Verify tag does not already exist
+      - name: Verify npm version is not already published
         run: |
+          published=$(npm view "${pkg_name}@${new_version}" version 2>/dev/null || true)
+          if [ -n "$published" ]; then
+            echo "npm version ${pkg_name}@${new_version} is already published" >&2
+            exit 1
+          fi
+
+      - name: Create or reuse tag
+        run: |
+          head_sha=$(git rev-parse HEAD)
+
+          local_target=""
           if git rev-parse -q --verify "refs/tags/${new_tag}" >/dev/null; then
-            echo "Tag ${new_tag} already exists locally" >&2
-            exit 1
-          fi
-          if git ls-remote --exit-code --tags origin "refs/tags/${new_tag}" >/dev/null 2>&1; then
-            echo "Tag ${new_tag} already exists on origin" >&2
-            exit 1
+            local_target=$(git rev-parse "refs/tags/${new_tag}^{commit}")
+            if [ "$local_target" = "$head_sha" ]; then
+              echo "Local tag ${new_tag} already points to HEAD (${head_sha}); reusing"
+            else
+              echo "Local tag ${new_tag} points to ${local_target}, not HEAD (${head_sha})" >&2
+              exit 1
+            fi
+          else
+            git tag "$new_tag"
           fi
 
-      - name: Create tag and GitHub release
-        run: |
-          git tag "$new_tag"
-          git push origin "$new_tag"
-          gh release create "$new_tag" --title "Release $new_tag" --notes "Release notes for $new_tag"
+          remote_sha=$(git ls-remote --tags origin "refs/tags/${new_tag}" | awk '{print $1}')
+          if [ -n "$remote_sha" ]; then
+            # ls-remote on an annotated tag returns the tag object sha; resolve to commit
+            remote_target=$(git rev-parse "refs/tags/${new_tag}^{commit}" 2>/dev/null || echo "$remote_sha")
+            if [ "$remote_target" = "$head_sha" ]; then
+              echo "Remote tag ${new_tag} already points to HEAD; skipping push"
+            else
+              echo "Remote tag ${new_tag} points to ${remote_target}, not HEAD (${head_sha})" >&2
+              exit 1
+            fi
+          else
+            git push origin "$new_tag"
+          fi
+
+      - name: Create or reuse GitHub release
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "$new_tag" >/dev/null 2>&1; then
+            echo "GitHub release ${new_tag} already exists; reusing"
+          else
+            gh release create "$new_tag" --title "Release $new_tag" --notes "Release notes for $new_tag"
+          fi
 
       - name: Publish package
         run: |

--- a/.github/workflows/release_sdk.yaml
+++ b/.github/workflows/release_sdk.yaml
@@ -3,6 +3,9 @@ name: 'Release SDK'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -19,7 +19,7 @@ jobs:
     container:
       image: semgrep/semgrep:1.157.0
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run Semgrep
         continue-on-error: true


### PR DESCRIPTION
### **User description**
Story: https://app.shortcut.com/smileid/story/xxx

## Summary

A few sentences/bullet points about the changes

## Known Issues

Any shortcomings in your work. This may include corner cases not correctly handled or issues related
to but not within the scope of your PR. Design compromises should be discussed here if they were not
already discussed above.

## Test Instructions

Concise test instructions on how to verify that your feature works as intended. This should include
changes to the development environment (if applicable) and all commands needed to run your work.

## Screenshot

If applicable (e.g. UI changes), add screenshots to help explain your work.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Refactor release_sdk workflow to read version from package.json instead of bumping

- Add tag validation and duplicate-tag checks before publishing

- Chain post_release workflow via `workflow_call` after publish

- Update docs path from react-native-v10 to react-native-v11


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["workflow_dispatch"] -- "triggers" --> B["CI (release job)"]
  B -- "needs" --> C["publish job"]
  C -- "read version" --> D["Validate & tag"]
  D -- "create release" --> E["npm publish"]
  C -- "outputs new_tag" --> F["post-release job"]
  F -- "workflow_call" --> G["Update docs release notes"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>post_release.yml</strong><dd><code>Add callable triggers and tag validation to post_release</code>&nbsp; </dd></summary>
<hr>

.github/workflows/post_release.yml

<ul><li>Added <code>workflow_call</code> and <code>workflow_dispatch</code> triggers with <code>tag_name</code> input<br> <li> Introduced <code>RELEASE_TAG</code> env variable resolved from inputs or release <br>event<br> <li> Added tag validation step (non-empty, valid semver format)<br> <li> Updated docs path from <code>react-native-v10</code> to <code>react-native-v11</code><br> <li> Replaced <code>github.event.release.tag_name</code> references with <code>env.RELEASE_TAG</code></ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/react-native-v11/pull/184/files#diff-7235ed47d43e54136a9c269dc833490c0d3b86f527f83edb114c879fa4ba6f66">+28/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>release_sdk.yaml</strong><dd><code>Simplify release flow with validation and chained post-release</code></dd></summary>
<hr>

.github/workflows/release_sdk.yaml

<ul><li>Removed version bump choice input; workflow now reads version from <br><code>package.json</code><br> <li> Added semver validation and duplicate-tag existence checks<br> <li> Replaced branch-based release flow with direct tag creation and GitHub <br>release<br> <li> Added <code>post-release</code> job that calls <code>post_release.yml</code> with the new tag<br> <li> Removed PR creation step; added proper git config and <code>GH_PAT</code> usage</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/react-native-v11/pull/184/files#diff-97147350ffb629aa876885032e2835283369cb38feb230c1582aa50d6dcb7681">+57/-56</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>