### PR TITLE
Add DefectDojo import step to Semgrep workflow

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -32,6 +32,31 @@ jobs:
         with:
           sarif_file: semgrep.sarif
 
+      - name: Import results into DefectDojo
+        if: always()
+        continue-on-error: true
+        env:
+          DEFECTDOJO_URL: ${{ secrets.DEFECTDOJO_URL }}
+          DEFECTDOJO_API_TOKEN: ${{ secrets.DEFECTDOJO_API_TOKEN }}
+        run: |
+          if [ ! -s semgrep.sarif ]; then
+            echo "No semgrep.sarif file found, skipping DefectDojo import"
+            exit 0
+          fi
+          curl -sS -f \
+            -H "Authorization: Token ${DEFECTDOJO_API_TOKEN}" \
+            -F "scan_type=SARIF" \
+            -F "file=@semgrep.sarif" \
+            -F "product_type_name=GitHub" \
+            -F "product_name=${{ github.event.repository.name }}" \
+            -F "engagement_name=CI" \
+            -F "auto_create_context=true" \
+            -F "close_old_findings=true" \
+            -F "deduplication_on_engagement=true" \
+            -F "commit_hash=${{ github.sha }}" \
+            -F "branch_tag=${{ github.head_ref || github.ref_name }}" \
+            "${DEFECTDOJO_URL}/api/v2/reimport-scan/"
+
       - name: Comment findings on PR
         if: github.event_name == 'pull_request' && always()
         env:


### PR DESCRIPTION
### **User description**
## Summary
- Adds a non-blocking "Import results into DefectDojo" step to `.github/workflows/semgrep.yml`, run after the existing "Upload SARIF to GitHub Security" step.
- Posts the Semgrep SARIF output to DefectDojo's `reimport-scan` API (`${{ secrets.DEFECTDOJO_URL }}/api/v2/reimport-scan/`) so findings get an aggregated view across repos instead of only living in PR checks.
- Uses the org-wide `DEFECTDOJO_URL` / `DEFECTDOJO_API_TOKEN` GitHub Actions secrets (already available to this repo) — no new secrets added.
- Mirrors `smileidentity/lambda#4662` (same template; currently open/unmerged, but proven working via its own pull_request-triggered CI run).

**SARIF filename used**: `semgrep.sarif` — this repo's Semgrep step (`semgrep scan --config p/security-audit --sarif -o semgrep.sarif`) writes to that exact path, same as lambda, so no filename adjustment was needed.

## Test plan
- [ ] Confirm this workflow run's new "Import results into DefectDojo" step executes and either successfully imports or gracefully skips (step must never fail the build: `continue-on-error: true`, `if: always()`, and a `[ -s semgrep.sarif ]` guard).
- [ ] Spot-check DefectDojo (https://defectdojo.smile.id) for a new/updated engagement named `CI` under a `react-native-v11` product after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Add DefectDojo import step to Semgrep CI workflow

- Posts SARIF results to DefectDojo reimport-scan API

- Non-blocking step with file existence guard

- Auto-creates product/engagement context in DefectDojo


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Semgrep Scan"] --> B["Upload SARIF to GitHub"]
  B --> C["Import to DefectDojo"]
  C --> D["Comment on PR"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>semgrep.yml</strong><dd><code>Add non-blocking DefectDojo reimport-scan step</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/semgrep.yml

<ul><li>Added a new "Import results into DefectDojo" step after the SARIF <br>upload step<br> <li> Uses <code>curl</code> to POST <code>semgrep.sarif</code> to DefectDojo's <code>reimport-scan</code> API <br>endpoint<br> <li> Includes guards: <code>if: always()</code>, <code>continue-on-error: true</code>, and a file <br>existence check (<code>[ ! -s semgrep.sarif ]</code>)<br> <li> Configures auto-creation of product/engagement context, deduplication, <br>and branch/commit metadata</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/react-native-v11/pull/214/files#diff-943c91ac8e5085136f071a01d6ad70ffe7beefb141dd4d45c3fc75c52c3c9dbb">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>