### PR TITLE
Fix shell-injection risk in DefectDojo import step

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -38,6 +38,8 @@ jobs:
         env:
           DEFECTDOJO_URL: ${{ secrets.DEFECTDOJO_URL }}
           DEFECTDOJO_API_TOKEN: ${{ secrets.DEFECTDOJO_API_TOKEN }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          BRANCH_TAG: ${{ github.head_ref || github.ref_name }}
         run: |
           if [ ! -s semgrep.sarif ]; then
             echo "No semgrep.sarif file found, skipping DefectDojo import"
@@ -48,13 +50,13 @@ jobs:
             -F "scan_type=SARIF" \
             -F "file=@semgrep.sarif" \
             -F "product_type_name=GitHub" \
-            -F "product_name=${{ github.event.repository.name }}" \
+            -F "product_name=${REPO_NAME}" \
             -F "engagement_name=CI" \
             -F "auto_create_context=true" \
             -F "close_old_findings=true" \
             -F "deduplication_on_engagement=true" \
             -F "commit_hash=${{ github.sha }}" \
-            -F "branch_tag=${{ github.head_ref || github.ref_name }}" \
+            -F "branch_tag=${BRANCH_TAG}" \
             "${DEFECTDOJO_URL}/api/v2/reimport-scan/"
 
       - name: Comment findings on PR


### PR DESCRIPTION
### **User description**
## Summary

Fixes a shell-injection risk (CWE-78) in the "Import results into DefectDojo" step of the Semgrep workflow, added in #214.

The step interpolates two GitHub Actions expressions directly into a `run: |` shell script via `${{ ... }}` templating, which GitHub substitutes as raw text into the script *before* the shell executes it:

- `${{ github.event.repository.name }}` in the `-F "product_name=..."` line
- `${{ github.head_ref || github.ref_name }}` in the `-F "branch_tag=..."` line

`github.head_ref` is the source branch name of a pull request, which is attacker-controllable — Git branch names can legally contain backticks and `$(...)` command substitution syntax. A maliciously named branch could inject arbitrary shell commands into this job, which has access to `secrets.DEFECTDOJO_API_TOKEN` and a repo-scoped `GITHUB_TOKEN`.

This is the same anti-pattern flagged by `prfectionist[bot]` on the reference implementation PR [smileidentity/lambda#4662](https://github.com/smileidentity/lambda/pull/4662), which PR #214 in this repo copied this workflow step from.

## Fix

Route both values through the step's `env:` block (which GitHub Actions passes as literal environment variable values, not script text) and reference them as shell variables (`$REPO_NAME`, `$BRANCH_TAG`) instead of interpolating `${{ }}` expressions directly into the shell script.

`${{ github.sha }}` (used for `commit_hash=`) is untouched — it's a full commit SHA, not attacker-controlled content, so it isn't a risk.

This is a minimal, surgical diff: two new `env:` keys, and two `run:` lines changed to reference them.

## Test plan

- [ ] Workflow YAML is valid (no syntax errors)
- [ ] Open a PR from a branch to confirm the DefectDojo import step still runs and posts the correct `product_name`/`branch_tag` values


___

### **PR Type**
Bug fix


___

### **Description**
- Fix shell-injection vulnerability in DefectDojo import step

- Route attacker-controllable expressions through `env:` block

- Replace `${{ }}` interpolation with shell variable references

- Prevents command injection via malicious branch names


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Attacker-controlled branch name"] -- "previously injected into" --> B["run: shell script"]
  A -- "now safely passed via" --> C["env: block"]
  C -- "referenced as" --> D["Shell variable $BRANCH_TAG"]
  D -- "used in" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>semgrep.yml</strong><dd><code>Mitigate shell injection via env variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/semgrep.yml

<ul><li>Added <code>REPO_NAME</code> and <code>BRANCH_TAG</code> environment variables to the step's <br><code>env:</code> block<br> <li> Replaced direct <code>${{ github.event.repository.name }}</code> interpolation with <br><code>${REPO_NAME}</code> shell variable<br> <li> Replaced direct <code>${{ github.head_ref || github.ref_name }}</code> <br>interpolation with <code>${BRANCH_TAG}</code> shell variable</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/react-native-v11/pull/216/files#diff-943c91ac8e5085136f071a01d6ad70ffe7beefb141dd4d45c3fc75c52c3c9dbb">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>