### PR TITLE
📙 docs: add an agents guide grounded in this wrapper's actual role

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,148 @@
+# SmileID React Native SDK (v11) — Agents Guide
+
+Guidance for AI coding agents working on the Smile ID React Native SDK v11. Humans welcome; tone
+optimised for tools.
+
+## What This Repo Is
+
+**`@smile_identity/react-native`** — a **thin wrapper** around the native Smile ID SDKs. The
+flows, capture UI, camera and ML all live natively; this package exposes them to JS as native
+view components plus a module surface. Smile ID provides digital KYC, identity verification, and
+onboarding across Africa; this is customer-facing product code.
+
+**This is the critical fact about this repo:** it is *not* where behaviour lives. A capture bug,
+a threshold change, or a liveness fix belongs in `smileidentity/android-v11` or
+`smileidentity/ios-sdk` — not here. This package passes configuration down and results back,
+faithfully.
+
+**v11 is the line partners are on today.** v12 is a separate, ground-up SDK where the React
+Native package is TypeScript-first, Expo-only and owns its own UI. Do not port v12 patterns
+here — the architectures are opposites.
+
+## Golden Rules
+
+- These rules encode decisions already made — don't relitigate them per change. If a rule
+  genuinely shouldn't apply, say so and ask; never silently deviate.
+- Precedence when sources disagree: **this file > existing code**. Code that violates a rule is
+  tracked legacy debt, not license to imitate.
+- Never claim something works or passes unless you actually ran it; list exactly what you
+  couldn't run.
+- Any partner-facing change adds a plain-language bullet to `CHANGELOG.md` in the same change.
+- When a new convention is agreed, record it in this file in the same change.
+- **Fix behaviour natively, not in TypeScript.** Wrapping around a native bug here creates
+  divergence between platforms instead of resolving it.
+
+## Commands
+
+```bash
+yarn lint            # ESLint
+yarn typecheck       # tsc
+yarn test            # Jest (CI adds --maxWorkers=2 --coverage)
+yarn prepare         # build the publishable output (CI runs this)
+yarn example         # the example app
+```
+
+**CI map:** per-PR gate = `ci.yml` — `yarn lint`, `yarn typecheck`, `yarn test` with coverage,
+then `yarn prepare`, plus Android and iOS example builds. Also `audit.yml` and `semgrep.yml`.
+Publishing is CI's job — never publish locally.
+
+## Architecture
+
+- `src/index.tsx` — the public surface
+- `src/NativeSmileId.ts` — the module interface
+- `src/SmileID*View.tsx` — one component per product (`SmileIDBiometricKYCView`,
+  `SmileIDDocumentCaptureView`, `SmileIDDocumentVerificationView`,
+  `SmileIDEnhancedDocumentVerificationView`, `SmileIDConsentView`, …). Each renders a **native
+  view**; the flow itself runs natively.
+- `src/__tests__/` — Jest tests
+- `android/` — Kotlin glue, namespace `com.smileidentity.react`
+- `react-native-smile-id.podspec` — iOS glue
+
+**There is no codegen.** `package.json` declares no `codegenConfig`, so despite the
+`NativeSmileId.ts` name this is **not** a TurboModule/Fabric package — it uses the legacy bridge.
+Don't add codegen config or new-architecture spec files without an explicit decision; doing so
+changes how every host app links this package.
+
+## Native Pins — read this before bumping
+
+The two platforms pin the native SDK differently, and the Android side is **host-overridable**:
+
+| platform | file | pin |
+|---|---|---|
+| Android | `android/build.gradle` | `com.smileidentity:android-sdk:$smile_id_sdk_version`, resolved from `rootProject.ext.smileIdAndroidSdkVersion` → else the `SmileId_androidVersion` property |
+| iOS | `react-native-smile-id.podspec` | `s.dependency "SmileID", "<version>"` (hard-pinned) |
+
+Two consequences:
+
+1. **Bump both together.** Shipping one platform on a newer native SDK than the other is how the
+   wrappers drift apart; state the native versions in the PR.
+2. **A host app can override the Android version and not the iOS one.** If you are debugging a
+   report where Android and iOS behave differently, check the host's
+   `smileIdAndroidSdkVersion` before assuming a wrapper bug.
+
+## Cross-Platform Parity
+
+This SDK has siblings on Android, iOS, Flutter and React Native (Expo). Parity is a contract:
+public type names, config fields **and their defaults**, and error-code strings stay aligned
+across the wrappers, and all must agree with the natives underneath.
+
+When you add or rename a public type or config field: **state the parity impact in the PR**, and
+mirror it in the sibling wrappers if they're available locally.
+
+Some divergences are intentional — notably ML threshold magnitudes differ between Android and
+iOS because ML Kit and Vision report head rotation differently. **Never "align" those by copying
+numbers across**; that breaks liveness on real devices while tests stay green.
+
+## Conventions
+
+- TypeScript with explicit props types per view component; `readonly` props and immutable data
+  shapes.
+- **No abbreviations**; spell out short locals (`viewModel` not `vm`); exceptions: loop counters
+  and `e` for caught errors.
+- **No business logic in this package.** TS configures, forwards, and surfaces results. If you
+  find yourself reimplementing a validation rule or state machine that exists natively, stop —
+  that's the divergence this wrapper exists to avoid.
+- No `any` without a justifying comment; narrow at the bridge boundary rather than casting.
+- Never log PII or secrets — no tokens, JWTs, signatures, images or partner params.
+
+## Testing
+
+- Jest tests in `src/__tests__/`, run with coverage in CI.
+- There is no visual/snapshot gate for the native views — they render natively, so UI-affecting
+  changes are verified by hand on a device. Say so in the PR.
+- **Every defect fix ships a test that fails before the fix**, at the tightest layer that
+  reproduces it; name it in the PR.
+- A test that passes and fails on the same commit is a defect in the test — fix or quarantine it,
+  never add retries.
+
+## Documentation
+
+**Comment discipline — default to no comment.** A comment earns its place only by stating a
+constraint or a WHY the code cannot express — never what the next line does. TSDoc on public API
+is one clear sentence plus the params that genuinely need explaining.
+
+Source comments stay self-contained: describe behaviour in this SDK's own terms. No comparisons
+to the v12 SDKs, no file paths into other repos.
+
+**Partner-facing docs:** any change partners can see or copy-paste — public API, props and their
+defaults, install coordinates, minimum requirements, error codes, permissions, README
+quick-start — needs a matching docs update or a "Docs impact" note in the PR description.
+
+## Definition of Done
+
+- ⚠️ **Ask first:** new dependencies; native SDK version bumps; anything that would introduce
+  codegen / new-architecture specs.
+- 🚫 **Never:** commit secrets; log PII; publish packages; reimplement native behaviour in TS.
+
+Before finishing any change:
+
+- [ ] `yarn lint`, `yarn typecheck`, `yarn test` green, and `yarn prepare` succeeds
+- [ ] Native pin bumped → **both** `android/build.gradle` and the podspec, versions stated in the
+      PR
+- [ ] Public surface changed → parity impact stated; sibling wrappers mirrored
+- [ ] UI-affecting change → verified on a device and stated as such
+- [ ] `CHANGELOG.md` bullet for anything partner-visible
+- [ ] Self-review in priority order — security (no PII/secrets in logs) → bridge contract (props
+      and events match the natives on both sides) → reliability (error paths surfaced, not
+      swallowed) → architecture (no behaviour reimplemented in TS) → readability. If you can't
+      describe a concrete failure scenario, don't flag it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
### **User description**
Adds `AGENTS.md` (+ a one-line `CLAUDE.md` include) so AI agents and new contributors get this
package's settled decisions and gotchas up front. Each v12 SDK carries one; v11 — the line
partners are running — had none.

**Docs only. No code, no config, no build changes.**

## Written from this repo, not copied from v12

v12's React Native guide describes an **Expo-only, TypeScript-first SDK that owns its own UI**.
This package is a **legacy-bridge wrapper whose flows run natively**. Copying that guide across
would have instructed contributors to work against the architecture.

The rule this repo most needs is about its own role, and it's the first thing the guide states:
**behaviour belongs in the native SDKs, not in TypeScript.** Patching around a native bug here
creates divergence between Android and iOS instead of resolving it.

Verified against the code:

| claim | verified against |
|---|---|
| `src/` surface + per-product view components | `src/index.tsx`, `src/NativeSmileId.ts`, `src/SmileID*View.tsx` |
| gate sequence: lint → typecheck → test w/ coverage → prepare → example builds | `.github/workflows/ci.yml` |
| **no codegen** — legacy bridge, not TurboModule/Fabric | no `codegenConfig` in `package.json` |
| Android pin is host-overridable | `android/build.gradle` (`rootProject.ext.smileIdAndroidSdkVersion` → `SmileId_androidVersion`) |
| iOS pin is hard-coded | `react-native-smile-id.podspec` |

## The finding most worth having written down

**A host app can override the Android native SDK version but not the iOS one.** Android resolves
`com.smileidentity:android-sdk` through `rootProject.ext.smileIdAndroidSdkVersion` (falling back
to the `SmileId_androidVersion` property), while the podspec hard-pins `SmileID`.

So when a bug report says "Android behaves differently from iOS", that may be the host's
override rather than anything in this wrapper. The guide says to check it before assuming — and
makes bumping both pins together a checklist item, since shipping one platform ahead of the
other is how the wrappers drift.

## Other guardrails captured

- **Don't add codegen / new-architecture specs casually.** The `NativeSmileId.ts` filename
  suggests a TurboModule; there's no `codegenConfig`, so it isn't one. Adding it changes how
  every host app links this package — flagged as an ask-first decision.
- **ML threshold divergence between Android and iOS is deliberate**, because ML Kit and Vision
  report head rotation differently. Copying numbers across "to align them" breaks liveness on
  real devices while tests stay green.
- No visual/snapshot gate exists for the native views, so UI-affecting changes are documented as
  hand-verified on a device — rather than implying a gate that would silently not run.

Companion PRs add the equivalent guide to the other v11 repos.


___

### **PR Type**
Documentation


___

### **Description**
- Add `AGENTS.md` guide for AI agents and contributors

- Document wrapper role, native pins, parity rules

- Add `CLAUDE.md` as one-line include of `AGENTS.md`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  AGENTS["AGENTS.md guide"] -- "included by" --> CLAUDE["CLAUDE.md"]
  AGENTS -- "documents" --> Rules["golden rules, native pins, parity"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AGENTS.md</strong><dd><code>Add repo-specific agents guide</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

AGENTS.md

<ul><li>New agents guide for v11 React Native SDK wrapper<br> <li> States behaviour belongs in native SDKs, not TypeScript<br> <li> Documents commands, architecture, no-codegen fact<br> <li> Explains host-overridable Android pin vs hard-pinned iOS</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/react-native-v11/pull/225/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+148/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CLAUDE.md</strong><dd><code>Add CLAUDE.md include of AGENTS.md</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CLAUDE.md

<ul><li>One-line include referencing <code>AGENTS.md</code><br> <li> Ensures both tools read the same source</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/react-native-v11/pull/225/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>