### PR TITLE
🙈 chore(deps): stop dependabot re-opening npm bumps we keep declining

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,17 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: '@babel/core'
+      - dependency-name: brace-expansion
+      - dependency-name: fast-uri
+      - dependency-name: joi
+      - dependency-name: js-yaml
+      - dependency-name: shell-quote
+      - dependency-name: tar
+      - dependency-name: turbo
+      - dependency-name: vm2
+      - dependency-name: ws
   - package-ecosystem: gradle
     open-pull-requests-limit: 0
     directory: /android


### PR DESCRIPTION
### **User description**
Story: N/A

![gif](https://media2.giphy.com/media/v1.Y2lkPWYwNzlmZTI2djdsNG5xZG13cjhtbjQ5Y282NzBldzJseWxxdzg0dTgyNDI5cjVobiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/G3DxVkOQFOHFagY2g3/giphy.gif)

## Summary

Dependabot recreates the same grouped npm security update PR every week, and we have closed every one of them without merging over the last 90 days (#196 to #230). This adds the 10 dependencies from those closed PRs to the ignore list in dependabot.yml so the PRs stop coming back:

- @babel/core
- brace-expansion
- fast-uri
- joi
- js-yaml
- shell-quote
- tar
- turbo
- vm2
- ws

## Known Issues

- Ignoring a dependency silences all future Dependabot updates for it, including new security advisories. Remove its entry when we are ready to take an update.
- The underlying advisories stay open on the repository's Dependabot alerts page; this change only stops the PRs.

## Test Instructions

- The YAML parses cleanly (validated locally with a YAML loader).
- After merging, Dependabot should stop recreating the closed npm group PRs on its next weekly run.

## Screenshot

N/A — no UI changes.


___

### **PR Type**
Other


___

### **Description**
- Add npm ignore list to Dependabot config

- Silences 10 repeatedly declined dependency bumps

- Prevents weekly recreation of closed PRs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dependabot weekly npm run"] -- "before" --> B["Grouped security PR reopened"]
  A -- "after: ignore list of 10 deps" --> C["No PR recreated"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependabot.yml</strong><dd><code>Ignore repeatedly declined npm dependency updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/dependabot.yml

<ul><li>Adds an <code>ignore</code> block to the npm ecosystem entry.<br> <li> Lists 10 dependencies (<code>@babel/core</code>, <code>brace-expansion</code>, <code>fast-uri</code>, <code>joi</code>, <br><code>js-yaml</code>, <code>shell-quote</code>, <code>tar</code>, <code>turbo</code>, <code>vm2</code>, <code>ws</code>) whose grouped update PRs <br>were closed without merging.<br> <li> Stops Dependabot from recreating those npm update pull requests, <br>including future advisories for them.</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/react-native-v11/pull/232/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>