### PR TITLE
fix(ci): pin release npm to 11.19.0 to unblock v11.2.0 publish

### DIFF
--- a/.github/workflows/release_sdk.yaml
+++ b/.github/workflows/release_sdk.yaml
@@ -107,7 +107,16 @@ jobs:
           fi
 
       - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
+        # OIDC trusted publishing needs npm >= 11.5.1; npm 12 requires Node >= 22
+        # while .nvmrc pins Node 20, so pin the npm 11 line exactly — the publish
+        # toolchain must not float at release time. Bump deliberately.
+        run: |
+          npm install -g npm@11.19.0
+          installed=$(npm --version)
+          if [ "$installed" != "11.19.0" ]; then
+            echo "Expected npm 11.19.0 on PATH, got $installed" >&2
+            exit 1
+          fi
 
       - name: Publish package
         run: |

--- a/.github/workflows/release_sdk.yaml
+++ b/.github/workflows/release_sdk.yaml
@@ -110,11 +110,14 @@ jobs:
         # OIDC trusted publishing needs npm >= 11.5.1; npm 12 requires Node >= 22
         # while .nvmrc pins Node 20, so pin the npm 11 line exactly — the publish
         # toolchain must not float at release time. Bump deliberately.
+        env:
+          NPM_VERSION: 11.19.0
         run: |
-          npm install -g npm@11.19.0
+          npm install -g "npm@${NPM_VERSION}"
+          hash -r
           installed=$(npm --version)
-          if [ "$installed" != "11.19.0" ]; then
-            echo "Expected npm 11.19.0 on PATH, got $installed" >&2
+          if [ "$installed" != "$NPM_VERSION" ]; then
+            echo "Expected npm ${NPM_VERSION} on PATH, got $installed" >&2
             exit 1
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,20 +3,20 @@
 ## 11.2.0 - August 7, 2026
 
 ### Changed
-* Bump Android SDK to [v11.2.0](https://github.com/smileidentity/android/releases/tag/v11.2.0)
+* Bump Android SDK to [v11.2.0](https://github.com/smileidentity/android-v11/releases/tag/v11.2.0)
 * Bump iOS SDK to [v11.2.0](https://github.com/smileidentity/ios/releases/tag/v11.2.0)
 
 ## 11.1.9 - May 15, 2026
 
 ### Changed
 * Made `forceAgentMode` and `allowAgentMode` optional.
-* Bump Android SDK to [v11.1.11](https://github.com/smileidentity/android/releases/tag/v11.1.11)
+* Bump Android SDK to [v11.1.11](https://github.com/smileidentity/android-v11/releases/tag/v11.1.11)
 * Bump iOS SDK to [v11.1.11](https://github.com/smileidentity/ios/releases/tag/v11.1.11)
 
 ## 11.1.8 - April 24, 2026
 
 ### Changed
-* Bump Android SDK to [v11.1.9](https://github.com/smileidentity/android/releases/tag/v11.1.9)
+* Bump Android SDK to [v11.1.9](https://github.com/smileidentity/android-v11/releases/tag/v11.1.9)
 * Bump iOS SDK to [v11.1.9](https://github.com/smileidentity/ios/releases/tag/v11.1.9)
 
 ### Added
@@ -32,13 +32,13 @@
 ## 11.1.7 - January 23, 2026
 
 ### Changed
-* Bump Android SDK to [v11.1.7](https://github.com/smileidentity/android/releases/tag/v11.1.7)
+* Bump Android SDK to [v11.1.7](https://github.com/smileidentity/android-v11/releases/tag/v11.1.7)
 * Bump iOS SDK to [v11.1.7](https://github.com/smileidentity/ios/releases/tag/v11.1.7)
 
 ## 11.1.3 - December 23, 2025
 
 ### Changed
-* Bump Android SDK to [v11.1.6](https://github.com/smileidentity/android/releases/tag/v11.1.6)
+* Bump Android SDK to [v11.1.6](https://github.com/smileidentity/android-v11/releases/tag/v11.1.6)
 * Bump iOS SDK to [v11.1.5](https://github.com/smileidentity/ios/releases/tag/v11.1.5)
 
 ### Added
@@ -47,7 +47,7 @@
 ## 11.1.2 - November 10, 2025
 
 ### Changed
-* Bump Android SDK to [v11.1.4](https://github.com/smileidentity/android/releases/tag/v11.1.4)
+* Bump Android SDK to [v11.1.4](https://github.com/smileidentity/android-v11/releases/tag/v11.1.4)
 * Bump iOS SDK to [v11.1.3](https://github.com/smileidentity/ios/releases/tag/v11.1.3)
 
 ## 11.1.1 - August 26, 2025
@@ -90,14 +90,14 @@
 ## 11.0.1 - June 16, 2025
 
 ### Changed
-* Bump android to 11.0.4 (https://github.com/smileidentity/android/releases/tag/v11.0.4)
+* Bump android to 11.0.4 (https://github.com/smileidentity/android-v11/releases/tag/v11.0.4)
 
 ## 11.0.0
 
 ### Changed
 * Metadata collection is now handled internally by native SDKs
 * Bump iOS to 11.0.0 (https://github.com/smileidentity/ios/releases/tag/v11.0.0)
-* Bump android to 11.0.3 (https://github.com/smileidentity/android/releases/tag/v11.0.3)
+* Bump android to 11.0.3 (https://github.com/smileidentity/android-v11/releases/tag/v11.0.3)
 
 ## 10.3.3
 


### PR DESCRIPTION
### **User description**
Story: https://app.shortcut.com/smileid/story/xxx

## Summary

The Release SDK run for v11.2.0 failed midway on main: it pushed the tag and created the GitHub release, then died before publishing to npm (registry latest is still 11.1.9). The failing step was `npm install -g npm@latest`, which now resolves to npm 12 — npm 12 needs Node 22, while `.nvmrc` pins Node 20, so the step failed with EBADENGINE.

This PR pins the step to npm 11.19.0 exactly — the npm 11 line still supports OIDC trusted publishing (which needs 11.5.1 or later) and runs on Node 20 — and fails fast if the pinned npm is not the one on PATH. It mirrors the fix already merged in the react-native-expo sibling (smileidentity/react-native-expo-v11#257), where the same failure broke the v11.2.11 release earlier today.

No partner-facing changes: CI only, so no CHANGELOG entry needed.

## Known Issues

- The root cause is the Node 20 pin (past end of life). Follow-up: bump `.nvmrc` and CI to Node 22, after which this pin can move to the npm 12 line.
- The exact pin means npm updates for the publish step now happen deliberately via PR, matching how the workflow's actions are SHA-pinned.

## Test Instructions

- The change only executes during a real release. After merging: delete the v11.2.0 tag and GitHub release (they point at the pre-fix commit, and the tag guard refuses a tag that does not match HEAD), then re-run the Release SDK workflow on main. The tag and release steps are idempotent (create or reuse) and the publish step now runs npm 11.19.0.

## Screenshot

Not applicable — no UI changes.

![gif](https://media2.giphy.com/media/v1.Y2lkPWYwNzlmZTI2aDVoOWE3cGY5MWozMWVxbjQ0MWhpNWpoaXc5czNpMTVyazV3NXcxayZlcD12MV9naWZzX3NlYXJjaCZjdD1n/VMu44c5bPw1kk/giphy.gif)


___

### **PR Type**
Bug fix


___

### **Description**
- Pin release npm to exact 11.19.0

- Avoid npm 12 EBADENGINE on Node 20

- Fail fast if pinned npm missing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Release workflow"] -- "was" --> B["npm install -g npm@latest"]
  B -- "npm 12 needs Node 22" --> C["EBADENGINE, publish fails"]
  A -- "now" --> D["npm install -g npm@11.19.0"]
  D -- "verify npm --version" --> E["Publish to npm via OIDC"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release_sdk.yaml</strong><dd><code>Pin npm version for release publish step</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release_sdk.yaml

<ul><li>Replaced <code>npm install -g npm@latest</code> with an exact pin to npm <code>11.19.0</code><br> <li> Added a version check that exits non-zero if the pinned npm is not on <br>PATH<br> <li> Added a comment explaining the OIDC (>= 11.5.1) and Node 20 <br>constraints</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/react-native-v11/pull/235/files#diff-97147350ffb629aa876885032e2835283369cb38feb230c1582aa50d6dcb7681">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>