### PR TITLE
⬆️ native: pin 11.2.1 on both platforms so the Sentry fixes reach React Native apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## Unreleased
+
+### Changed
+* Bump Android SDK to [v11.2.1](https://github.com/smileidentity/android-v11/releases/tag/v11.2.1)
+* Bump iOS SDK to [v11.2.1](https://github.com/smileidentity/ios/releases/tag/v11.2.1)
+
 ## 11.2.0 - August 7, 2026
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## Unreleased
+## 11.2.1 - August 14, 2026
 
 ### Changed
 * Bump Android SDK to [v11.2.1](https://github.com/smileidentity/android-v11/releases/tag/v11.2.1)

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,5 +3,5 @@ SmileId_minSdkVersion=21
 SmileId_targetSdkVersion=36
 SmileId_compileSdkVersion=36
 SmileId_ndkversion=21.4.7075529
-SmileId_androidVersion=11.2.0
+SmileId_androidVersion=11.2.1
 SmileId_kotlinCompilerExtensionVersion=1.5.11

--- a/ios/RNSmileID.swift
+++ b/ios/RNSmileID.swift
@@ -11,7 +11,7 @@ class RNSmileID: NSObject {
     resolve: @escaping RCTPromiseResolveBlock,
     reject _: @escaping RCTPromiseRejectBlock
   ) {
-    SmileID.setWrapperInfo(name: .reactNative, version: "11.2.0")
+    SmileID.setWrapperInfo(name: .reactNative, version: "11.2.1")
 
     // Handle different initialization scenarios based on provided parameters
     if let apiKey = apiKey, let config = config {

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,116 +1,99 @@
 # OSV-Scanner allowlist for triaged advisories.
 #
-# All entries below are transitive devDependencies (release tooling, linters,
-# builders, test runners). None are shipped to consumers of this package.
-# Re-triage before ignoreUntil; either bump the direct dep that brings them in
-# or extend the date with updated justification.
+# Every entry below is a transitive devDependency — release tooling, the Metro
+# bundler, linters, builders, test runners — and none of them ship to consumers of
+# this package. Each one is here because a lockfile refresh cannot reach the fixed
+# version: the parent pins an exact version, the fix is a major upgrade of the
+# parent, or upstream has published no fix at all. The reason on each entry says
+# which.
+#
+# Re-triaged 2026-08-14: the previous window had lapsed, which is what turned this
+# gate red. Everything reachable by a lockfile refresh was fixed in that pass
+# instead of being listed here — 36 vulnerabilities across 15 packages, including
+# vm2 and both ws versions — so this file is now only the genuinely unreachable
+# remainder.
+#
+# Before ignoreUntil: re-triage. Either bump the direct dependency that brings the
+# advisory in, or extend the date with updated justification. Do not extend blindly
+# — check first whether a fix has since become reachable.
+
+# --- release-it 15 chain: fixes need release-it 16+, a major upgrade -------------
 
 [[IgnoredVulns]]
 id = "GHSA-h5c3-5r3r-rr8q"
-ignoreUntil = 2026-07-20
-reason = "Transitive via release-it@15 (@octokit/plugin-paginate-rest). Dev-only."
+ignoreUntil = 2026-11-14
+reason = "@octokit/plugin-paginate-rest 6.1.2 via release-it@15. Fix is 9.2.2, three majors on, unreachable without upgrading release-it. Dev-only."
 
 [[IgnoredVulns]]
 id = "GHSA-rmvr-2pp2-xj38"
-ignoreUntil = 2026-07-20
-reason = "Transitive via release-it@15 (@octokit/request). Dev-only."
+ignoreUntil = 2026-11-14
+reason = "@octokit/request 6.2.8 via release-it@15. Fix is 8.4.1, two majors on. Dev-only."
 
 [[IgnoredVulns]]
 id = "GHSA-xx4v-prfh-6cgc"
-ignoreUntil = 2026-07-20
-reason = "Transitive via release-it@15 (@octokit/request-error). Dev-only."
-
-[[IgnoredVulns]]
-id = "GHSA-2g4f-4pwh-qvx6"
-ignoreUntil = 2026-07-20
-reason = "Transitive via eslint/jest/commitlint (ajv). Dev-only."
-
-[[IgnoredVulns]]
-id = "GHSA-6v7q-wjvx-w8wg"
-ignoreUntil = 2026-07-20
-reason = "Transitive via release-it@15 -> webdav (basic-ftp). Dev-only."
-
-[[IgnoredVulns]]
-id = "GHSA-rp42-5vxx-qpwr"
-ignoreUntil = 2026-07-20
-reason = "Transitive via release-it@15 -> webdav (basic-ftp). Dev-only."
-
-[[IgnoredVulns]]
-id = "GHSA-f886-m6hf-6m8v"
-ignoreUntil = 2026-07-20
-reason = "Transitive (brace-expansion) across multiple dev deps. Dev-only."
-
-[[IgnoredVulns]]
-id = "GHSA-73rr-hh4g-fpgx"
-ignoreUntil = 2026-07-20
-reason = "Transitive via jest (diff). Dev-only."
-
-[[IgnoredVulns]]
-id = "GHSA-5j98-mcp5-4vw2"
-ignoreUntil = 2026-07-20
-reason = "Transitive (glob) across multiple dev deps. Dev-only."
+ignoreUntil = 2026-11-14
+reason = "@octokit/request-error 3.0.3 via release-it@15. Fix is 5.1.1, two majors on. Dev-only."
 
 [[IgnoredVulns]]
 id = "GHSA-2p57-rm9w-gvfp"
-ignoreUntil = 2026-07-20
-reason = "Transitive (ip@1.1.9) via release-it -> webdav. No fixed version available upstream; revisit when fix is published or dep is removed."
-
-[[IgnoredVulns]]
-id = "GHSA-mh29-5h37-fv8m"
-ignoreUntil = 2026-07-20
-reason = "Transitive (js-yaml) across multiple dev deps. Dev-only."
-
-[[IgnoredVulns]]
-id = "GHSA-f23m-r3pf-42rh"
-ignoreUntil = 2026-07-20
-reason = "Transitive via @release-it/conventional-changelog (lodash). Dev-only."
-
-[[IgnoredVulns]]
-id = "GHSA-r5fr-rjxr-66jc"
-ignoreUntil = 2026-07-20
-reason = "Transitive via @release-it/conventional-changelog (lodash). Dev-only."
-
-[[IgnoredVulns]]
-id = "GHSA-xxjr-mmjv-4gpg"
-ignoreUntil = 2026-07-20
-reason = "Transitive via @release-it/conventional-changelog (lodash). Dev-only."
-
-[[IgnoredVulns]]
-id = "GHSA-23c5-xmqv-rm74"
-ignoreUntil = 2026-07-20
-reason = "Transitive (minimatch) across multiple dev deps. Dev-only."
-
-[[IgnoredVulns]]
-id = "GHSA-3ppc-4f35-3m26"
-ignoreUntil = 2026-07-20
-reason = "Transitive (minimatch) across multiple dev deps. Dev-only."
-
-[[IgnoredVulns]]
-id = "GHSA-7r86-cg39-jmmj"
-ignoreUntil = 2026-07-20
-reason = "Transitive (minimatch) across multiple dev deps. Dev-only."
-
-[[IgnoredVulns]]
-id = "GHSA-3v7f-55p6-f55p"
-ignoreUntil = 2026-07-20
-reason = "Transitive (picomatch) via dev deps. Dev-only."
-
-[[IgnoredVulns]]
-id = "GHSA-c2c7-rcm5-vvqj"
-ignoreUntil = 2026-07-20
-reason = "Transitive (picomatch) via dev deps. Dev-only."
+ignoreUntil = 2026-11-14
+reason = "ip 1.1.9 via release-it@15 -> webdav. No fixed version published upstream. Dev-only."
 
 [[IgnoredVulns]]
 id = "GHSA-c2qf-rxjj-qqgw"
-ignoreUntil = 2026-07-20
-reason = "Transitive (semver) across multiple dev deps. Dev-only."
+ignoreUntil = 2026-11-14
+reason = "semver 7.3.8 and 7.5.1, pinned exactly by release-it@15 and @release-it/conventional-changelog, so a refresh cannot move them. Dev-only."
+
+[[IgnoredVulns]]
+id = "GHSA-f23m-r3pf-42rh"
+ignoreUntil = 2026-11-14
+reason = "lodash 4.17.21, pinned exactly via @release-it/conventional-changelog. Fix is 4.18.0. Dev-only."
+
+[[IgnoredVulns]]
+id = "GHSA-r5fr-rjxr-66jc"
+ignoreUntil = 2026-11-14
+reason = "lodash 4.17.21, pinned exactly via @release-it/conventional-changelog. Fix is 4.18.0. Dev-only."
+
+# --- Metro bundler: build-time only, no fix published ---------------------------
+
+[[IgnoredVulns]]
+id = "GHSA-5p2g-fcmc-qvqq"
+ignoreUntil = 2026-11-14
+reason = "image-size 1.2.1 via metro 0.80.12 (React Native bundler). No fixed version published upstream. Build-time only."
+
+[[IgnoredVulns]]
+id = "GHSA-w3rx-r6r6-pgpr"
+ignoreUntil = 2026-11-14
+reason = "image-size 1.2.1 via metro 0.80.12. No fixed version published upstream. Build-time only."
+
+# --- dev tooling where the fix is a major upgrade of the parent -----------------
+
+[[IgnoredVulns]]
+id = "GHSA-mwp4-54f8-5fhr"
+ignoreUntil = 2026-11-14
+reason = "ip-address 9.0.5 via socks@^2.8.3. Fix is 10.x, a major the parent's range excludes. Dev-only."
+
+[[IgnoredVulns]]
+id = "GHSA-v2v4-37r5-5v8g"
+ignoreUntil = 2026-11-14
+reason = "ip-address 9.0.5 via socks@^2.8.3. Fix is 10.x, a major the parent's range excludes. Dev-only."
 
 [[IgnoredVulns]]
 id = "GHSA-52f5-9888-hmc6"
-ignoreUntil = 2026-07-20
-reason = "Transitive (tmp) via dev deps. Dev-only."
+ignoreUntil = 2026-11-14
+reason = "tmp 0.0.33 via external-editor and patch-package. Fix is 0.2.x, and a 0.x minor is a breaking change the ^0.0.33 range cannot take. Dev-only."
 
 [[IgnoredVulns]]
-id = "GHSA-48c2-rrv3-qjmp"
-ignoreUntil = 2026-07-20
-reason = "Transitive (yaml) via dev deps. Dev-only."
+id = "GHSA-ph9p-34f9-6g65"
+ignoreUntil = 2026-11-14
+reason = "tmp 0.0.33 via external-editor and patch-package. Fix is 0.2.x, outside the ^0.0.33 range. Dev-only."
+
+[[IgnoredVulns]]
+id = "GHSA-3qcw-2rhx-2726"
+ignoreUntil = 2026-11-14
+reason = "turbo 1.13.4, a direct devDependency pinned ^1.10.7. Fix is 2.x, which changes turbo.json's schema (pipeline -> tasks), so it needs its own change. Build-time only."
+
+[[IgnoredVulns]]
+id = "GHSA-hcf7-66rw-9f5r"
+ignoreUntil = 2026-11-14
+reason = "turbo 1.13.4, a direct devDependency pinned ^1.10.7. Fix is 2.x, a schema-changing major. Build-time only."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smile_identity/react-native",
-  "version": "11.2.0",
+  "version": "11.2.1",
   "description": "Official wrapper for the Smile ID >v10 android and iOS SDKs",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/react-native-smile-id.podspec
+++ b/react-native-smile-id.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://docs.usesmileid.com/.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
-  s.dependency "SmileID", "11.2.0"
+  s.dependency "SmileID", "11.2.1"
   # for development alongside example/ios/Podfile uncomment the version and specify
   # tag or branch in example/ios/Podfile
   # s.dependency "SmileID"

--- a/sample/ios/Podfile.lock
+++ b/sample/ios/Podfile.lock
@@ -2,11 +2,6 @@ PODS:
   - boost (1.83.0)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.74.2)
-  - FingerprintJS (1.6.0):
-    - FingerprintJS/Core (= 1.6.0)
-  - FingerprintJS/Core (1.6.0):
-    - FingerprintJS/SystemControl
-  - FingerprintJS/SystemControl (1.6.0)
   - fmt (9.1.0)
   - glog (0.3.5)
   - hermes-engine (0.74.2):
@@ -942,7 +937,7 @@ PODS:
     - React-debug
   - react-native-safe-area-context (4.14.1):
     - React-Core
-  - react-native-smile-id (11.2.0):
+  - react-native-smile-id (11.2.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -962,7 +957,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - SmileID (= 11.2.0)
+    - SmileID (= 11.2.1)
     - Yoga
   - React-nativeconfig (0.74.2)
   - React-NativeModulesApple (0.74.2):
@@ -1215,18 +1210,11 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - Sentry (8.58.4):
-    - Sentry/Core (= 8.58.4)
-  - Sentry/Core (8.58.4)
-  - SmileID (11.2.0):
-    - SmileIDSDK (= 11.2.0)
-  - SmileIDSDK (11.2.0):
-    - FingerprintJS (= 1.6.0)
-    - Sentry (~> 8.57)
-    - ZIPFoundation (= 0.9.20)
+  - SmileID (11.2.1):
+    - SmileIDSDK (= 11.2.1)
+  - SmileIDSDK (11.2.1)
   - SocketRocket (0.7.0)
   - Yoga (0.0.0)
-  - ZIPFoundation (0.9.20)
 
 DEPENDENCIES:
   - boost (from `../node_modules/react-native/third-party-podspecs/boost.podspec`)
@@ -1291,12 +1279,9 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
-    - FingerprintJS
-    - Sentry
     - SmileID
     - SmileIDSDK
     - SocketRocket
-    - ZIPFoundation
 
 EXTERNAL SOURCES:
   boost:
@@ -1419,7 +1404,6 @@ SPEC CHECKSUMS:
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
   DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
   FBLazyVector: 4bc164e5b5e6cfc288d2b5ff28643ea15fa1a589
-  FingerprintJS: 3a0c3e7f5035ecae199e5e5836200d9b20f1266a
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
   glog: fdfdfe5479092de0c4bdbebedd9056951f092c4f
   hermes-engine: 01d3e052018c2a13937aca1860fbedbccd4a41b7
@@ -1448,7 +1432,7 @@ SPEC CHECKSUMS:
   React-logger: 70e002e04cc56ff5c12157537405d1644c050703
   React-Mapbuffer: 8d1f0fc6e7280a8ed6da70ece5f283ac5c8032cb
   react-native-safe-area-context: 758e894ca5a9bd1868d2a9cfbca7326a2b6bf9dc
-  react-native-smile-id: 6c18567a82156af4caf4f928094d995d5c027264
+  react-native-smile-id: b2edb9bbe18672f50950b6c5c14799503199ca3e
   React-nativeconfig: 9f223cd321823afdecf59ed00861ab2d69ee0fc1
   React-NativeModulesApple: 1cd770ed7dc463e55d02a05f7fc3be46076d393e
   React-perflogger: 32ed45d9cee02cf6639acae34251590dccd30994
@@ -1473,12 +1457,10 @@ SPEC CHECKSUMS:
   React-utils: 08bb648cea0f37a0aa5df0c4f9ef50e5484ee0eb
   ReactCommon: 4968ff446d467c4def1945125e59f82e3e986af3
   RNScreens: 02747ebee17d2e322af4ee383877367cf82a3cd6
-  Sentry: 5321d74bdd28d6f6f8beaa1ca06f1fdc746bff49
-  SmileID: 848c46109ef664eae1491c78642b273e4a0997c5
-  SmileIDSDK: d4888e5df8039f2eec1f10a31c81bd681262d911
+  SmileID: 8a64fd13da9bd1a8b623496ad32d225b5d378583
+  SmileIDSDK: 022ac26d652546120578ec37675434289e315001
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   Yoga: ae3c32c514802d30f687a04a6a35b348506d411f
-  ZIPFoundation: dfd3d681c4053ff7e2f7350bc4e53b5dba3f5351
 
 PODFILE CHECKSUM: c75f928dd028b436fe16e4dfd48d42eb9de51e2a
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,16 +5,6 @@ __metadata:
   version: 6
   cacheKey: 8
 
-"@ampproject/remapping@npm:^2.2.0":
-  version: 2.3.0
-  resolution: "@ampproject/remapping@npm:2.3.0"
-  dependencies:
-    "@jridgewell/gen-mapping": ^0.3.5
-    "@jridgewell/trace-mapping": ^0.3.24
-  checksum: d3ad7b89d973df059c4e8e6d7c972cbeb1bb2f18f002a3bd04ae0707da214cb06cc06929b65aa2313b9347463df2914772298bae8b1d7973f246bb3f2ab3e8f0
-  languageName: node
-  linkType: hard
-
 "@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/code-frame@npm:7.27.1"
@@ -48,6 +38,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/code-frame@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/code-frame@npm:7.29.7"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.29.7
+    js-tokens: ^4.0.0
+    picocolors: ^1.1.1
+  checksum: 21b12fe2356e36f6cc3cd8a3721f878bfeea80ce38356979a0518b47b3aafdcc0bd263da75ccc9d51c64d40b1b6df00e768ce2446acb0b7cbec0ae8f905663ad
+  languageName: node
+  linkType: hard
+
 "@babel/compat-data@npm:^7.20.5, @babel/compat-data@npm:^7.27.2, @babel/compat-data@npm:^7.27.7, @babel/compat-data@npm:^7.28.0":
   version: 7.28.0
   resolution: "@babel/compat-data@npm:7.28.0"
@@ -55,26 +56,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/compat-data@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/compat-data@npm:7.29.7"
+  checksum: 4424f8fb72f61657c8e811bdf7e5c69af212a15fe362711162b2e00b82f0e0588fb8259ecd9a70c5490562bf51d408b0cb92f277ead71a2390ddddfe7283b35d
+  languageName: node
+  linkType: hard
+
 "@babel/core@npm:^7.11.6, @babel/core@npm:^7.12.3, @babel/core@npm:^7.13.16, @babel/core@npm:^7.18.5, @babel/core@npm:^7.20.0, @babel/core@npm:^7.23.9":
-  version: 7.28.0
-  resolution: "@babel/core@npm:7.28.0"
+  version: 7.29.7
+  resolution: "@babel/core@npm:7.29.7"
   dependencies:
-    "@ampproject/remapping": ^2.2.0
-    "@babel/code-frame": ^7.27.1
-    "@babel/generator": ^7.28.0
-    "@babel/helper-compilation-targets": ^7.27.2
-    "@babel/helper-module-transforms": ^7.27.3
-    "@babel/helpers": ^7.27.6
-    "@babel/parser": ^7.28.0
-    "@babel/template": ^7.27.2
-    "@babel/traverse": ^7.28.0
-    "@babel/types": ^7.28.0
+    "@babel/code-frame": ^7.29.7
+    "@babel/generator": ^7.29.7
+    "@babel/helper-compilation-targets": ^7.29.7
+    "@babel/helper-module-transforms": ^7.29.7
+    "@babel/helpers": ^7.29.7
+    "@babel/parser": ^7.29.7
+    "@babel/template": ^7.29.7
+    "@babel/traverse": ^7.29.7
+    "@babel/types": ^7.29.7
+    "@jridgewell/remapping": ^2.3.5
     convert-source-map: ^2.0.0
     debug: ^4.1.0
     gensync: ^1.0.0-beta.2
     json5: ^2.2.3
     semver: ^6.3.1
-  checksum: 86da9e26c96e22d96deca0509969d273476f61c30464f262dec5e5a163422e07d5ab690ed54619d10fcab784abd10567022ce3d90f175b40279874f5288215e3
+  checksum: 95149e98ffde5b9d903459c284fbcf1f9ad8b3a833d69fdfe1aa7185821a102af1925324fe2892caf4b643b151c1dc948510d1e25a5e3c6c6c6f17f6712eb38e
   languageName: node
   linkType: hard
 
@@ -118,6 +126,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/generator@npm:^7.29.7, @babel/generator@npm:^7.29.8":
+  version: 7.29.8
+  resolution: "@babel/generator@npm:7.29.8"
+  dependencies:
+    "@babel/parser": ^7.29.8
+    "@babel/types": ^7.29.8
+    "@jridgewell/gen-mapping": ^0.3.12
+    "@jridgewell/trace-mapping": ^0.3.28
+    jsesc: ^3.0.2
+  checksum: e3d80ad2ce45ca974cb14e084350d590aa62e840d5028bb7771e910b1727b6646afcc9815560e3c6e3526f115b71b18a7f7139ada76a80287d5bd25b84c17e8d
+  languageName: node
+  linkType: hard
+
 "@babel/helper-annotate-as-pure@npm:^7.27.1, @babel/helper-annotate-as-pure@npm:^7.27.3":
   version: 7.27.3
   resolution: "@babel/helper-annotate-as-pure@npm:7.27.3"
@@ -137,6 +158,19 @@ __metadata:
     lru-cache: ^5.1.1
     semver: ^6.3.1
   checksum: 7b95328237de85d7af1dea010a4daa28e79f961dda48b652860d5893ce9b136fc8b9ea1f126d8e0a24963b09ba5c6631dcb907b4ce109b04452d34a6ae979807
+  languageName: node
+  linkType: hard
+
+"@babel/helper-compilation-targets@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-compilation-targets@npm:7.29.7"
+  dependencies:
+    "@babel/compat-data": ^7.29.7
+    "@babel/helper-validator-option": ^7.29.7
+    browserslist: ^4.24.0
+    lru-cache: ^5.1.1
+    semver: ^6.3.1
+  checksum: f60a943937f4eba0e671aa28551cb45569fd081c1e30a52ede167860475dc0417f3dbdf2a0fa3f086965595c7070aa76308da60cc0319860de05db4ed2a431f7
   languageName: node
   linkType: hard
 
@@ -201,6 +235,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-globals@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-globals@npm:7.29.7"
+  checksum: 6deaf9846a415c7f110ac153e8c3d81e3543c9b685aa9fd9a59b4235f402e2b760129d3df49466daea9162f0cf73ff98a0ec7f180448a3449ca14ae5e1117b42
+  languageName: node
+  linkType: hard
+
 "@babel/helper-member-expression-to-functions@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/helper-member-expression-to-functions@npm:7.27.1"
@@ -231,7 +272,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-transforms@npm:^7.27.1, @babel/helper-module-transforms@npm:^7.27.3":
+"@babel/helper-module-imports@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-module-imports@npm:7.29.7"
+  dependencies:
+    "@babel/traverse": ^7.29.7
+    "@babel/types": ^7.29.7
+  checksum: ad5a768fc9c162620b7f5b7645c6c2efee1e6f9df432bb79651888661a7e4cd91dac7192f3ddcfd6de4778a089e9fb30fafae768156aa73a07eeca425f64e849
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-transforms@npm:^7.27.1":
   version: 7.27.3
   resolution: "@babel/helper-module-transforms@npm:7.27.3"
   dependencies:
@@ -254,6 +305,19 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: 522f7d1d08b5e2ccd4ec912aca879bd1506af78d1fb30f46e3e6b4bb69c6ae6ab4e379a879723844230d27dc6d04a55b03f5215cd3141b7a2b40bb4a02f71a9f
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-transforms@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-module-transforms@npm:7.29.7"
+  dependencies:
+    "@babel/helper-module-imports": ^7.29.7
+    "@babel/helper-validator-identifier": ^7.29.7
+    "@babel/traverse": ^7.29.7
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 484f6d02975d304f680d44e331d4b832d67e51917483985eab7b853664452b5a627366e7a9d421200ec772a123213a591e28b40636566afeac189411ba3f45a8
   languageName: node
   linkType: hard
 
@@ -323,6 +387,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-string-parser@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-string-parser@npm:7.29.7"
+  checksum: 4c229d2c2296b6c94439e87ecddf3a93cee3ffd2d4cee0b4c28079275bed3de4e02cd943e4cb06036d1d9407549c4e3423006b61a46215c482fce902ee02bc0b
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-identifier@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/helper-validator-identifier@npm:7.27.1"
@@ -337,10 +408,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-validator-identifier@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-validator-identifier@npm:7.29.7"
+  checksum: cc7779e96fe9c9478c96ca4bf04fc338b95b501aa5abe78178307dea282d4a5dc23d443efb12dde8e8c5636d03dd00e443532e6ed7f15fa7977349af1f87ba4d
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-option@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/helper-validator-option@npm:7.27.1"
   checksum: db73e6a308092531c629ee5de7f0d04390835b21a263be2644276cb27da2384b64676cab9f22cd8d8dbd854c92b1d7d56fc8517cf0070c35d1c14a8c828b0903
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-option@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-validator-option@npm:7.29.7"
+  checksum: aeb6aa966f59300d3cc2fea7c68e1dfd7ad011fc10e535c8e2b2de3094b27c859428dc7220f16420350f8b1cde99da120b673be04bcb0c2f37b56258c96bed58
   languageName: node
   linkType: hard
 
@@ -355,13 +440,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helpers@npm:^7.27.6":
-  version: 7.29.2
-  resolution: "@babel/helpers@npm:7.29.2"
+"@babel/helpers@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helpers@npm:7.29.7"
   dependencies:
-    "@babel/template": ^7.28.6
-    "@babel/types": ^7.29.0
-  checksum: 2c8ce711a639ef334539d3bd48977f57493f71af99e13d3f685fe47b3bc32aa83dbc1380688e19d5df924d958f8f29072f3dcff8110257ba6399524907287189
+    "@babel/template": ^7.29.7
+    "@babel/types": ^7.29.7
+  checksum: b5c4ed0ce5983c5599cd01b3948444b77ba2fa47bf6282a82afdcbe45eb8cc5b7986194e3920ef2760f533c6a775504e6b00a66960c0a3bc52909920b8433908
   languageName: node
   linkType: hard
 
@@ -395,6 +480,17 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: 046f46996bf4053b6e29f8a7f420f9e0a2878593c1c9a9914a36faca23fc544a307c78a0101ba3ae98936ade68bdde686a83e1ab2b74c2ebb80dc4a9df48476d
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.29.7, @babel/parser@npm:^7.29.8":
+  version: 7.29.8
+  resolution: "@babel/parser@npm:7.29.8"
+  dependencies:
+    "@babel/types": ^7.29.8
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: c8bbea3c87b8593e78e8901841b068cc004ece24bf3ee44e11b4a3e04f10dab513125ca290c2cc04ba981399b662dbebb0a675016417d600e99272e86d59b375
   languageName: node
   linkType: hard
 
@@ -1718,6 +1814,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/template@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/template@npm:7.29.7"
+  dependencies:
+    "@babel/code-frame": ^7.29.7
+    "@babel/parser": ^7.29.7
+    "@babel/types": ^7.29.7
+  checksum: 521eb6a1fd4735074ca8dac0d70810860a80edf3bf78105851571993cd13701a2041987e7398ccc9376eb6235ea1258bf494ccaccf3b67fa98dbe954154a2e93
+  languageName: node
+  linkType: hard
+
 "@babel/traverse@npm:^7.20.0, @babel/traverse@npm:^7.27.1, @babel/traverse@npm:^7.27.3, @babel/traverse@npm:^7.28.0":
   version: 7.28.0
   resolution: "@babel/traverse@npm:7.28.0"
@@ -1748,6 +1855,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/traverse@npm:^7.29.7":
+  version: 7.29.8
+  resolution: "@babel/traverse@npm:7.29.8"
+  dependencies:
+    "@babel/code-frame": ^7.29.7
+    "@babel/generator": ^7.29.8
+    "@babel/helper-globals": ^7.29.7
+    "@babel/parser": ^7.29.8
+    "@babel/template": ^7.29.7
+    "@babel/types": ^7.29.8
+    debug: ^4.3.1
+  checksum: 7c33eb59db5c67411305ed1d29fe50dbde74b220f4500840951d776fbcc3fbddca09f57302e8961d2533871ef4719ec0f2f05969870263b180d6ff4217f7acee
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.24.7, @babel/types@npm:^7.27.1, @babel/types@npm:^7.27.3, @babel/types@npm:^7.28.0, @babel/types@npm:^7.28.2, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4":
   version: 7.28.2
   resolution: "@babel/types@npm:7.28.2"
@@ -1775,6 +1897,16 @@ __metadata:
     "@babel/helper-string-parser": ^7.27.1
     "@babel/helper-validator-identifier": ^7.28.5
   checksum: 83f190438e94c22b2574aaeef7501830311ef266eaabfb06523409f64e2fe855e522951607085d71cad286719adef14e1ba37b671f334a7cd25b0f8506a01e0b
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.29.7, @babel/types@npm:^7.29.8":
+  version: 7.29.8
+  resolution: "@babel/types@npm:7.29.8"
+  dependencies:
+    "@babel/helper-string-parser": ^7.29.7
+    "@babel/helper-validator-identifier": ^7.29.7
+  checksum: 9ac45d1fc702bce8e51f74566c85211f4a5d06b6f921c297e07f05742ac0eb9660d4380f96ac18d882415e4e1172e92a3fc7a20b29afd2277b713efc5b3c7cf6
   languageName: node
   linkType: hard
 
@@ -2397,6 +2529,16 @@ __metadata:
     "@jridgewell/sourcemap-codec": ^1.5.0
     "@jridgewell/trace-mapping": ^0.3.24
   checksum: 56ee1631945084897f274e65348afbaca7970ce92e3c23b3a23b2fe5d0d2f0c67614f0df0f2bb070e585e944bbaaf0c11cee3a36318ab8a36af46f2fd566bc40
+  languageName: node
+  linkType: hard
+
+"@jridgewell/remapping@npm:^2.3.5":
+  version: 2.3.5
+  resolution: "@jridgewell/remapping@npm:2.3.5"
+  dependencies:
+    "@jridgewell/gen-mapping": ^0.3.5
+    "@jridgewell/trace-mapping": ^0.3.24
+  checksum: 4a66a7397c3dc9c6b5c14a0024b1f98c5e1d90a0dbc1e5955b5038f2db339904df2a0ee8a66559fafb4fc23ff33700a2639fd40bbdd2e9e82b58b3bdf83738e3
   languageName: node
   linkType: hard
 
@@ -3803,26 +3945,26 @@ __metadata:
   linkType: hard
 
 "ajv@npm:^6.12.4":
-  version: 6.12.6
-  resolution: "ajv@npm:6.12.6"
+  version: 6.15.0
+  resolution: "ajv@npm:6.15.0"
   dependencies:
     fast-deep-equal: ^3.1.1
     fast-json-stable-stringify: ^2.0.0
     json-schema-traverse: ^0.4.1
     uri-js: ^4.2.2
-  checksum: 874972efe5c4202ab0a68379481fbd3d1b5d0a7bd6d3cc21d40d3536ebff3352a2a1fabb632d4fd2cc7fe4cbdcd5ed6782084c9bbf7f32a1536d18f9da5007d4
+  checksum: a8e0308f1b44c3dfd1143911353be51bf8aedc2f2bcd595061755ad241c8450a10e4b657af8ba764c5ec9ae2162010f21d5e0d43763e20d782a8171da99b967a
   languageName: node
   linkType: hard
 
 "ajv@npm:^8.11.0":
-  version: 8.17.1
-  resolution: "ajv@npm:8.17.1"
+  version: 8.20.0
+  resolution: "ajv@npm:8.20.0"
   dependencies:
     fast-deep-equal: ^3.1.3
     fast-uri: ^3.0.1
     json-schema-traverse: ^1.0.0
     require-from-string: ^2.0.2
-  checksum: 1797bf242cfffbaf3b870d13565bd1716b73f214bb7ada9a497063aada210200da36e3ed40237285f3255acc4feeae91b1fb183625331bad27da95973f7253d9
+  checksum: 4f18ca5fcccff8c8b9a4d6f1a6a3a70ffc888e787624ca66f2d0162e04e8f9f2d289d8a1acdb9520d18bffcee975e7a789a9f8292b5c2c577c408cd2c3308cad
   languageName: node
   linkType: hard
 
@@ -4383,21 +4525,21 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^1.1.7":
-  version: 1.1.14
-  resolution: "brace-expansion@npm:1.1.14"
+  version: 1.1.18
+  resolution: "brace-expansion@npm:1.1.18"
   dependencies:
     balanced-match: ^1.0.0
     concat-map: 0.0.1
-  checksum: 2de747a5891ea0d3a1946ea1ae26e056a47f7ea8d42a3009e1736ec3a31a5aa69a3c5da59d998426773553afe4c258e5b12d7953b534fa7f2cf12ce92eed4931
+  checksum: aa84023a4118f9185b6f8c71ca3467c945878b141ba340261de209676442f81b08db5b7c7c119707cdecb7322fcfcdb71d8ffea55db9d1aad673d7c65469211f
   languageName: node
   linkType: hard
 
 "brace-expansion@npm:^2.0.1, brace-expansion@npm:^2.0.2":
-  version: 2.1.0
-  resolution: "brace-expansion@npm:2.1.0"
+  version: 2.1.4
+  resolution: "brace-expansion@npm:2.1.4"
   dependencies:
     balanced-match: ^1.0.0
-  checksum: c77a7a64aabf94b8d5913955adb4f36957917565374461355bb4276830c027a313d981f32410cea9e38f52573e7eb776d02fe05091c3a79a061958d97e4d2b43
+  checksum: a2e0b87c1d348fe7a424f8e383e113ac9c4f111753dba60069aa22d55de6855695bf83f56d9a96c92fb14f42be17e272d5a2761eac7e25ca6687fa2b6efa44a8
   languageName: node
   linkType: hard
 
@@ -5704,9 +5846,9 @@ __metadata:
   linkType: hard
 
 "diff@npm:^4.0.1":
-  version: 4.0.2
-  resolution: "diff@npm:4.0.2"
-  checksum: f2c09b0ce4e6b301c221addd83bf3f454c0bc00caa3dd837cf6c127d6edf7223aa2bbe3b688feea110b7f262adbfc845b757c44c8a9f8c0c5b15d8fa9ce9d20d
+  version: 4.0.4
+  resolution: "diff@npm:4.0.4"
+  checksum: e3f1c368778b16f9e7e4fd4199d04913bba9b017c37fbca7642b3613ebefcf3b18a4bd55e5f7074dc023fc95c96bd265f72114044e62cebae7f9a0f53bc36ace
   languageName: node
   linkType: hard
 
@@ -6582,9 +6724,9 @@ __metadata:
   linkType: hard
 
 "fast-uri@npm:^3.0.1":
-  version: 3.1.2
-  resolution: "fast-uri@npm:3.1.2"
-  checksum: 73a6e1b04e6fcf7a09ed93316e72d643ef177d26969973784690708612141f2c2f74657120bab75bf5bbc26bfd535a32c90a8c3bc50aca50584cf01f98815afe
+  version: 3.1.5
+  resolution: "fast-uri@npm:3.1.5"
+  checksum: 8a95af13e0730ac5c3abeb7f3939dee9fa95f2652e0ebac7a072b5597f836200084340c9bc2030f392318cdb49ec04e3fd6f558fa24c58d6d373557b9c01d7fb
   languageName: node
   linkType: hard
 
@@ -8884,15 +9026,15 @@ __metadata:
   linkType: hard
 
 "joi@npm:^17.2.1":
-  version: 17.13.3
-  resolution: "joi@npm:17.13.3"
+  version: 17.13.4
+  resolution: "joi@npm:17.13.4"
   dependencies:
     "@hapi/hoek": ^9.3.0
     "@hapi/topo": ^5.1.0
     "@sideway/address": ^4.1.5
     "@sideway/formula": ^3.0.1
     "@sideway/pinpoint": ^2.0.0
-  checksum: 66ed454fee3d8e8da1ce21657fd2c7d565d98f3e539d2c5c028767e5f38cbd6297ce54df8312d1d094e62eb38f9452ebb43da4ce87321df66cf5e3f128cbc400
+  checksum: 99e0a784f08cb0b6910bd42df094e4f3f047c2589c61b139b7eb25a21f814478a1d3b5c68134bbcc4153ac216cbae2710a2b7f56605974e5c66a0ebdfab08e8f
   languageName: node
   linkType: hard
 
@@ -8904,25 +9046,25 @@ __metadata:
   linkType: hard
 
 "js-yaml@npm:^3.13.1":
-  version: 3.14.2
-  resolution: "js-yaml@npm:3.14.2"
+  version: 3.15.1
+  resolution: "js-yaml@npm:3.15.1"
   dependencies:
     argparse: ^1.0.7
     esprima: ^4.0.0
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 626fc207734a3452d6ba84e1c8c226240e6d431426ed94d0ab043c50926d97c509629c08b1d636f5d27815833b7cfd225865631da9fb33cb957374490bf3e90b
+  checksum: 536cfb984b61d1544dbdbe394254dd13481a94171cb3a61608572d9112a63cbace9dd900cb83a4e530ac36427fff77d9e1cb6734917c6fea951d00b4f7bbb163
   languageName: node
   linkType: hard
 
 "js-yaml@npm:^4.1.0":
-  version: 4.1.1
-  resolution: "js-yaml@npm:4.1.1"
+  version: 4.3.1
+  resolution: "js-yaml@npm:4.3.1"
   dependencies:
     argparse: ^2.0.1
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: ea2339c6930fe048ec31b007b3c90be2714ab3e7defcc2c27ebf30c74fd940358f29070b4345af0019ef151875bf3bc3f8644bea1bab0372652b5044813ac02d
+  checksum: 482740e69a1769b355d7182234c0fa197237f02e6a5c8c0b70a763af6a712c9741de350d784a5659e00cf03cedd6ebfa506d59ca45967e3ee50dd4f4df18f2e7
   languageName: node
   linkType: hard
 
@@ -9953,20 +10095,20 @@ __metadata:
   linkType: hard
 
 "minimatch@npm:^5.0.1":
-  version: 5.1.6
-  resolution: "minimatch@npm:5.1.6"
+  version: 5.1.9
+  resolution: "minimatch@npm:5.1.9"
   dependencies:
     brace-expansion: ^2.0.1
-  checksum: 7564208ef81d7065a370f788d337cd80a689e981042cb9a1d0e6580b6c6a8c9279eba80010516e258835a988363f99f54a6f711a315089b8b42694f5da9d0d77
+  checksum: 418438bd7701ba811f1108f28fcd3a638a6065c7b1245b85e25bcdb674410b4bebd8763c90c91bc8d22d93260c02cc129b354267a463c3399be5732d6e11e120
   languageName: node
   linkType: hard
 
 "minimatch@npm:^8.0.2":
-  version: 8.0.4
-  resolution: "minimatch@npm:8.0.4"
+  version: 8.0.7
+  resolution: "minimatch@npm:8.0.7"
   dependencies:
     brace-expansion: ^2.0.1
-  checksum: 2e46cffb86bacbc524ad45a6426f338920c529dd13f3a732cc2cf7618988ee1aae88df4ca28983285aca9e0f45222019ac2d14ebd17c1edadd2ee12221ab801a
+  checksum: edaefeb16297f4f3969287913adb04c12c5683f2bd8610c6d6bfd5aa5b98bbbfd6013a2d0bb24df62e8add9c265128df1bfdbb61bb043ef4aa86b449fc2a9c76
   languageName: node
   linkType: hard
 
@@ -10138,11 +10280,11 @@ __metadata:
   linkType: hard
 
 "nanoid@npm:^3.1.23":
-  version: 3.3.12
-  resolution: "nanoid@npm:3.3.12"
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 38699257447dc59e21e73e0510d0dfb16b7a610d9ca80633d5c3a68f9b4298c990513d30404ca8f163c2d03225ee01695ff8898bea6179183f38f0477b7635ac
+  checksum: db804317d337b41602666f23014e399d1263033d13a903955c246378256fd4e002519e87199ca40b19aff52274965ac7cc6e70c13a63e194e15c4664724602d3
   languageName: node
   linkType: hard
 
@@ -12140,11 +12282,11 @@ __metadata:
   linkType: hard
 
 "semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.5.2, semver@npm:^7.5.3, semver@npm:^7.5.4":
-  version: 7.7.2
-  resolution: "semver@npm:7.7.2"
+  version: 7.8.5
+  resolution: "semver@npm:7.8.5"
   bin:
     semver: bin/semver.js
-  checksum: dd94ba8f1cbc903d8eeb4dd8bf19f46b3deb14262b6717d0de3c804b594058ae785ef2e4b46c5c3b58733c99c83339068203002f9e37cfe44f7e2cc5e3d2f621
+  checksum: 0c580f17e88e2b45806dc5cf3d824f719c946999d3554bf30307c2b68b3300ab3c8bfcd84d8f489b93b4cbb5362f5fc8de4d2858954f18d834253c4450fc9f6b
   languageName: node
   linkType: hard
 
@@ -12265,9 +12407,9 @@ __metadata:
   linkType: hard
 
 "shell-quote@npm:^1.6.1, shell-quote@npm:^1.7.3":
-  version: 1.8.3
-  resolution: "shell-quote@npm:1.8.3"
-  checksum: 550dd84e677f8915eb013d43689c80bb114860649ec5298eb978f40b8f3d4bc4ccb072b82c094eb3548dc587144bb3965a8676f0d685c1cf4c40b5dc27166242
+  version: 1.10.0
+  resolution: "shell-quote@npm:1.10.0"
+  checksum: d4bc0757ae0e493d0f6e3327c93be7d5af1d39e9969eb4332ed4e40bb2c3f9112ec31e979d713d302605f7e3431d9f5f061719e0e177077ffd9c03c0b9cc5f73
   languageName: node
   linkType: hard
 
@@ -12863,15 +13005,15 @@ __metadata:
   linkType: hard
 
 "tar@npm:^7.4.3":
-  version: 7.5.11
-  resolution: "tar@npm:7.5.11"
+  version: 7.5.22
+  resolution: "tar@npm:7.5.22"
   dependencies:
     "@isaacs/fs-minipass": ^4.0.0
     chownr: ^3.0.0
     minipass: ^7.1.2
     minizlib: ^3.1.0
     yallist: ^5.0.0
-  checksum: 7f6785a85dd571b88985e493ec86f692962cbfa7b4017961fddfd2241e0ff3bcd89ed347f4c02b5433aa22b30cca5566e8711543df054fda8fd12425f505378f
+  checksum: e1434f40954410d191ab6d89017bfd40c24869cfd319d19dd74f84db13cbea15370a22bc9b8ecd699d05c2777ec6297f35dac318ed4829b6e776a7cb4f1f7c68
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13590,14 +13590,14 @@ __metadata:
   linkType: hard
 
 "vm2@npm:^3.9.19":
-  version: 3.11.3
-  resolution: "vm2@npm:3.11.3"
+  version: 3.11.5
+  resolution: "vm2@npm:3.11.5"
   dependencies:
     acorn: ^8.15.0
     acorn-walk: ^8.3.4
   bin:
     vm2: bin/vm2
-  checksum: 9696d3ec64a95a4b7c390cf94ef1bb7b324d03788827e38a98c0bf69c70c4ce86a754a87caf8e1c1f880f5a90f534dcbca7775509c5d6e66359da9f7fa4dc17b
+  checksum: f45b09f28df96696bb5869b0c0e9acf0a91d9dbc27c0e64b0e500480c6de33d92d645bd5b2bc56a9466ee4b8f856d02eb45d1b165d4b957cc7e5f10d9dccdc77
   languageName: node
   linkType: hard
 
@@ -13860,17 +13860,17 @@ __metadata:
   linkType: hard
 
 "ws@npm:^6.2.2":
-  version: 6.2.3
-  resolution: "ws@npm:6.2.3"
+  version: 6.2.6
+  resolution: "ws@npm:6.2.6"
   dependencies:
     async-limiter: ~1.0.0
-  checksum: bbc96ff5628832d80669a88fd117487bf070492dfaa50df77fa442a2b119792e772f4365521e0a8e025c0d51173c54fa91adab165c11b8e0674685fdd36844a5
+  checksum: a112f68d8a876ac50a72dc180518f10955a94497f6dcb475d66d92400d36079bbabe24f204e820c3765470831c967f4ab7a38f138cb17e17172697677403848b
   languageName: node
   linkType: hard
 
 "ws@npm:^7, ws@npm:^7.5.10":
-  version: 7.5.10
-  resolution: "ws@npm:7.5.10"
+  version: 7.5.13
+  resolution: "ws@npm:7.5.13"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ^5.0.2
@@ -13879,7 +13879,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: f9bb062abf54cc8f02d94ca86dcd349c3945d63851f5d07a3a61c2fcb755b15a88e943a63cf580cbdb5b74436d67ef6b67f745b8f7c0814e411379138e1863cb
+  checksum: 2c3e3526d99fcc9792992d5e62b152583869b5f0e9d62f5cf12b8cda36bf0b66b33feabf320c16e22d901415f8770138635129cec56afc3d4212f791f7f630a2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### **User description**
Story: N/A — native pin bump

![keeping in sync](https://media3.giphy.com/media/v1.Y2lkPTM4ZDczMDY1ZXc4dmYxb2dsMmM0dXFveDJuc3gxemF3Z2U3amJoamtkcWF4eHV1ayZlcD12MV9naWZzX3NlYXJjaCZjdD1n/h7Y3T8lzocy2ixMg2Z/giphy-downsized.gif)

## Summary

Picks up the 11.2.1 native SDKs. That release closes out the Sentry backlog: on Android the
capture crashes, the submission races and the startup ANRs; on iOS the SmartSelfie result decode
failure that was the largest single source of errors by volume.

Both platforms move in the same change, so neither side ships against an older SDK than the other.

This also cuts the wrapper release: `package.json` moves to 11.2.1, matching the native version.

Verified the pinned artifacts exist rather than assuming:

* `com.smileidentity:android-sdk:11.2.1` resolves from Maven Central.
* The `smileidentity/ios` `v11.2.1` tag and its release assets exist.

## Known Issues

* The CocoaPods `SmileID` pod for 11.2.1 is not on Trunk yet, so any job that runs `pod install`
  will fail until it lands. That is not a problem with this change. The per-version `SmileIDSDK`
  spec is already published, and `SmileID` is pushed by a separate workflow once Trunk's aggregate
  index catches up — it lags the per-version spec by 30 minutes to several hours by design,
  because `SmileID` declares an exact dependency on `SmileIDSDK`. Re-run the checks after that,
  and this goes green on its own.
* The committed sample `Podfile.lock` files still resolve 11.2.0. They have to be regenerated with
  `pod install` once the pod is available, which cannot be done from this change.
* `android/gradle.properties` (`SmileId_androidVersion`) and `react-native-smile-id.podspec`
  both move.
* `ios/RNSmileID.swift` reports the wrapper version through `setWrapperInfo` as a hardcoded string,
  so it moves to 11.2.1 with `package.json`. The Android side reads the version from `package.json`
  at build time and needs no edit.

## Test Instructions

```bash
yarn install
cd sample/android && ./gradlew assembleDebug     # resolves android-sdk 11.2.1 from Maven
```

The iOS side needs the pod on Trunk first; after that, `cd sample/ios && pod install`.

## Screenshot

N/A — no UI changes.


___

### **PR Type**
Other


___

### **Description**
- Pin iOS `SmileID` pod to 11.2.1

- Pin Android SDK version to 11.2.1

- Add unreleased CHANGELOG entry for both bumps


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Native SDK pin 11.2.0"] -- "bump" --> B["11.2.1"]
  B --> C["android/gradle.properties"]
  B --> D["react-native-smile-id.podspec"]
  B --> E["CHANGELOG.md Unreleased"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>react-native-smile-id.podspec</strong><dd><code>Bump iOS SmileID pod to 11.2.1</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

react-native-smile-id.podspec

- Bumps the iOS `SmileID` pod dependency from 11.2.0 to 11.2.1


</details>


  </td>
  <td><a href="https://github.com/smileidentity/react-native-v11/pull/240/files#diff-13a3668001b7d56ec0435e0b3f6e6af5f08f45881dbd1143521eaf7a8386a0de">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gradle.properties</strong><dd><code>Bump Android native SDK version to 11.2.1</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

android/gradle.properties

<ul><li>Updates <code>SmileId_androidVersion</code> from 11.2.0 to 11.2.1, the default <br>Android native SDK pin</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/react-native-v11/pull/240/files#diff-3ab34fb625c346ec8377e7204444075ec41563ca1227c9a231df8c966386de89">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document the 11.2.1 native bumps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Adds an <code>Unreleased</code> section with <code>Changed</code> bullets<br> <li> Links the Android and iOS v11.2.1 release notes</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/react-native-v11/pull/240/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>
